### PR TITLE
Automatically change keyboard layout for Swedish

### DIFF
--- a/recovery/languagedialog.cpp
+++ b/recovery/languagedialog.cpp
@@ -188,6 +188,10 @@ void LanguageDialog::changeLanguage(const QString &langcode)
     {
         defaultKeyboardLayout = "jp";
     }
+    else if (langcode == "sv")
+    {
+        defaultKeyboardLayout = "se";
+    }
     else
     {
         defaultKeyboardLayout = langcode.left(2); /* Use only 2 letter keyboard code as best guess */


### PR DESCRIPTION
Added if statement to languagedialog.cpp in the same way as for
Japanese to automatically switch to Swedish keyboard layout
when Swedish language is chosen.