### PR TITLE
Update ca-certs and blacklist DST Root CA X3

### DIFF
--- a/buildroot/package/ca-certificates/001-blacklist-dst-root-ca-x3.patch
+++ b/buildroot/package/ca-certificates/001-blacklist-dst-root-ca-x3.patch
@@ -1,0 +1,9 @@
+blacklist expired "DST Root CA X3".
+
+--- a/work/mozilla/blacklist.txt
++++ b/work/mozilla/blacklist.txt
+@@ -7,3 +7,4 @@
+ "MITM subCA 2 issued by Trustwave"
+ "TURKTRUST Mis-issued Intermediate CA 1"
+ "TURKTRUST Mis-issued Intermediate CA 2"
++"DST Root CA X3"

--- a/buildroot/package/ca-certificates/ca-certificates.hash
+++ b/buildroot/package/ca-certificates/ca-certificates.hash
@@ -1,6 +1,6 @@
 # hashes from: $(CA_CERTIFICATES_SITE)/ca-certificates_$(CA_CERTIFICATES_VERSION).dsc :
-sha1   47d4584eae85fc905e4994766eb3930a8a84e2e1                         ca-certificates_20190110.tar.xz
-sha256 ee4bf0f4c6398005f5b5ca4e0b87b82837ac5c3b0280a1cb3a63c47555c3a675 ca-certificates_20190110.tar.xz
+sha1  c9875aa16e42981c6975e59a11727539053e2299  ca-certificates_20210119.tar.xz
+sha256  daa3afae563711c30a0586ddae4336e8e3974c2b627faaca404c4e0141b64665  ca-certificates_20210119.tar.xz
 
 # Locally computed
-sha256 80fd11117df5543d5cf17bfd951b0ead213f7867d0b09f09c6d5a5eca3ff7422 debian/copyright
+sha256  e85e1bcad3a915dc7e6f41412bc5bdeba275cadd817896ea0451f2140a93967c  debian/copyright

--- a/buildroot/package/ca-certificates/ca-certificates.mk
+++ b/buildroot/package/ca-certificates/ca-certificates.mk
@@ -7,8 +7,8 @@
 CA_CERTIFICATES_VERSION = 20210119
 CA_CERTIFICATES_SOURCE = ca-certificates_$(CA_CERTIFICATES_VERSION).tar.xz
 CA_CERTIFICATES_SITE = https://snapshot.debian.org/archive/debian/20210325T091936Z/pool/main/c/ca-certificates
-CA_CERTIFICATES_DEPENDENCIES = host-openssl host-python3
-CA_CERTIFICATES_LICENSE = GPL-2.0+ (script), MPL-2.0 (data)
+CA_CERTIFICATES_DEPENDENCIES = host-openssl host-python
+CA_CERTIFICATES_LICENSE = GPLv2+ (script), MPLv2.0 (data)
 CA_CERTIFICATES_LICENSE_FILES = debian/copyright
 
 define CA_CERTIFICATES_BUILD_CMDS
@@ -33,7 +33,7 @@ define CA_CERTIFICATES_INSTALL_TARGET_CMDS
 	done >$(@D)/ca-certificates.crt
 
 	# Create symlinks to the certificates by their hash values
-	$(HOST_DIR)/bin/c_rehash $(TARGET_DIR)/etc/ssl/certs
+	$(HOST_DIR)/usr/bin/c_rehash $(TARGET_DIR)/etc/ssl/certs
 
 	# Install the certificates bundle
 	$(INSTALL) -D -m 644 $(@D)/ca-certificates.crt \

--- a/buildroot/package/ca-certificates/ca-certificates.mk
+++ b/buildroot/package/ca-certificates/ca-certificates.mk
@@ -4,11 +4,11 @@
 #
 ################################################################################
 
-CA_CERTIFICATES_VERSION = 20190110
+CA_CERTIFICATES_VERSION = 20210119
 CA_CERTIFICATES_SOURCE = ca-certificates_$(CA_CERTIFICATES_VERSION).tar.xz
-CA_CERTIFICATES_SITE = http://snapshot.debian.org/archive/debian/20190513T145054Z/pool/main/c/ca-certificates
-CA_CERTIFICATES_DEPENDENCIES = host-openssl host-python
-CA_CERTIFICATES_LICENSE = GPLv2+ (script), MPLv2.0 (data)
+CA_CERTIFICATES_SITE = https://snapshot.debian.org/archive/debian/20210325T091936Z/pool/main/c/ca-certificates
+CA_CERTIFICATES_DEPENDENCIES = host-openssl host-python3
+CA_CERTIFICATES_LICENSE = GPL-2.0+ (script), MPL-2.0 (data)
 CA_CERTIFICATES_LICENSE_FILES = debian/copyright
 
 define CA_CERTIFICATES_BUILD_CMDS
@@ -33,12 +33,11 @@ define CA_CERTIFICATES_INSTALL_TARGET_CMDS
 	done >$(@D)/ca-certificates.crt
 
 	# Create symlinks to the certificates by their hash values
-	$(HOST_DIR)/usr/bin/c_rehash $(TARGET_DIR)/etc/ssl/certs
+	$(HOST_DIR)/bin/c_rehash $(TARGET_DIR)/etc/ssl/certs
 
 	# Install the certificates bundle
 	$(INSTALL) -D -m 644 $(@D)/ca-certificates.crt \
-	$(TARGET_DIR)/etc/ssl/certs/ca-certificates.crt
-
+		$(TARGET_DIR)/etc/ssl/certs/ca-certificates.crt
 endef
 
 $(eval $(generic-package))


### PR DESCRIPTION
1st commit updating ca-certs to 20210119 (just copied from latest buildroot)
2nd commit adding patch to blacklist DST Root CA X3.

I'm still not sure how to build PINN to test, so the patch file may not be correct
but you can see what needs to be done

Ubuntu has released a new 20210119 version with this patch already applied
https://launchpad.net/ubuntu/+source/ca-certificates/20210119~18.04.2

i cant see a version in debian distro yet though.
So, we could either do this with the patch, or change the source to grab from ubuntu
https://launchpad.net/ubuntu/+archive/primary/+sourcefiles/ca-certificates/20210119~18.04.2/ca-certificates_20210119~18.04.2.tar.xz