### PR TITLE
Update ca certs to 20210119ubuntu1

### DIFF
--- a/buildroot/package/ca-certificates/ca-certificates.hash
+++ b/buildroot/package/ca-certificates/ca-certificates.hash
@@ -1,6 +1,6 @@
 # hashes from: $(CA_CERTIFICATES_SITE)/ca-certificates_$(CA_CERTIFICATES_VERSION).dsc :
-sha1   47d4584eae85fc905e4994766eb3930a8a84e2e1                         ca-certificates_20190110.tar.xz
-sha256 ee4bf0f4c6398005f5b5ca4e0b87b82837ac5c3b0280a1cb3a63c47555c3a675 ca-certificates_20190110.tar.xz
+sha1  0631ab0f5cd67dbeb8e8e26d5e65876940cfdbf5  ca-certificates_20210119ubuntu1.tar.xz
+sha256  1bf2e615ad883ccdd0bf93266ae0eb33c23ff12bcf45df4e62eeebdcfbf6e80b  ca-certificates_20210119ubuntu1.tar.xz
 
 # Locally computed
-sha256 80fd11117df5543d5cf17bfd951b0ead213f7867d0b09f09c6d5a5eca3ff7422 debian/copyright
+sha256  e85e1bcad3a915dc7e6f41412bc5bdeba275cadd817896ea0451f2140a93967c  debian/copyright

--- a/buildroot/package/ca-certificates/ca-certificates.mk
+++ b/buildroot/package/ca-certificates/ca-certificates.mk
@@ -4,9 +4,9 @@
 #
 ################################################################################
 
-CA_CERTIFICATES_VERSION = 20190110
+CA_CERTIFICATES_VERSION = 20210119ubuntu1
 CA_CERTIFICATES_SOURCE = ca-certificates_$(CA_CERTIFICATES_VERSION).tar.xz
-CA_CERTIFICATES_SITE = http://snapshot.debian.org/archive/debian/20190513T145054Z/pool/main/c/ca-certificates
+CA_CERTIFICATES_SITE = http://us.archive.ubuntu.com/ubuntu/pool/main/c/ca-certificates
 CA_CERTIFICATES_DEPENDENCIES = host-openssl host-python
 CA_CERTIFICATES_LICENSE = GPLv2+ (script), MPLv2.0 (data)
 CA_CERTIFICATES_LICENSE_FILES = debian/copyright


### PR DESCRIPTION
this is 20210119 with DST Root CA X3 blacklisted which should hopefully fix our SSL issues
I dont think the debian distro has this yet (i couldn't find) so simply changed the source to ubuntu

https://launchpad.net/ubuntu/+source/ca-certificates/20210119~18.04.2
http://launchpadlibrarian.net/559670736/ca-certificates_20210119~18.04.1_20210119~18.04.2.diff.gz

The key is blacklisting the old DST Root CA X3.
https://www.openssl.org/blog/blog/2021/09/13/LetsEncryptRootCertExpire/
(option 1)

both this and current 20190110 have the needed ISRG Root X1 (exp 2035)

_Another method would be just to use a patch to add DST Root CA X3 to mozilla/blacklist.txt_