### PR TITLE
Fix package download error

### DIFF
--- a/buildroot/package/pigz/pigz.mk
+++ b/buildroot/package/pigz/pigz.mk
@@ -5,7 +5,7 @@
 #############################################################
 PIGZ_VERSION = 2.4
 PIGZ_SOURCE = pigz-$(PIGZ_VERSION).tar.gz
-PIGZ_SITE = zlib.net/pigz
+PIGZ_SITE = sources.buildroot.net/pigz
 #download.freenas.org/distfiles
 PIGZ_CAT = $(ZCAT)
 PIGZ_DIR = $(BUILD_DIR)/pigz-$(PIGZ_VERSION)


### PR DESCRIPTION
Looks like https://zlib.net/pigz/ now only has version 2.7, and trying to download version 2.4 results in a 404 error