### PR TITLE
Updated translation_de.ts

### DIFF
--- a/recovery/translation_de.ts
+++ b/recovery/translation_de.ts
@@ -6,7 +6,7 @@
     <message>
         <location filename="backupthread.cpp" line="66"/>
         <source>Finish writing (sync)</source>
-        <translation>Schließe Schreibvorgang ab (sync)</translation>
+        <translation> Schreibvorgang abschließen (sync)</translation>
     </message>
     <message>
         <location filename="backupthread.cpp" line="113"/>
@@ -16,7 +16,7 @@
     <message>
         <location filename="backupthread.cpp" line="113"/>
         <source> :BTRFS file format</source>
-        <translation> :BTRFS Dateiformat</translation>
+        <translation> :BTRFS-Dateiformat</translation>
     </message>
     <message>
         <location filename="backupthread.cpp" line="235"/>
@@ -46,7 +46,7 @@
     <message>
         <location filename="backupthread.cpp" line="218"/>
         <source>%1: Checksumming (%2)</source>
-        <translation type="unfinished"></translation>
+        <translation>%1: Prüfsumme wird erstellt (%2)</translation>
     </message>
     <message>
         <location filename="backupthread.cpp" line="256"/>
@@ -64,7 +64,7 @@
     <message>
         <location filename="bootselectiondialog.cpp" line="72"/>
         <source>Error mounting settings partition</source>
-        <translation>Fehler beim Einbinden der Einstellungspartition</translation>
+        <translation>Fehler beim Einhängen der Einstellungspartition</translation>
     </message>
     <message>
         <location filename="bootselectiondialog.cpp" line="328"/>
@@ -84,44 +84,44 @@
     <message>
         <location filename="bootselectiondialog.cpp" line="378"/>
         <source>PINN - Previously selected OS will boot in %1 seconds</source>
-        <translation>PINN - Das als letzes ausgewählte Betriebsystem wird in %1 Sekunden starten</translation>
+        <translation>PINN - Das zuletzt ausgewählte Betriebssystem startet in %1 Sekunden</translation>
     </message>
     <message>
         <location filename="bootselectiondialog.ui" line="25"/>
         <location filename="bootselectiondialog.cpp" line="380"/>
         <source>PINN - Select OS to boot</source>
-        <translation>Wähle ein Betriebsystem zum starten aus</translation>
+        <translation>PINN - Zu startendes Betriebssystem auswählen</translation>
     </message>
     <message>
         <location filename="bootselectiondialog.ui" line="38"/>
         <source>Sticky default</source>
-        <translation type="unfinished"></translation>
+        <translation>Als Standard vermerkt</translation>
     </message>
     <message>
         <location filename="bootselectiondialog.ui" line="45"/>
         <source>&amp;Up</source>
         <oldsource>Up</oldsource>
-        <translation type="unfinished"></translation>
+        <translation>Nach &amp;oben</translation>
     </message>
     <message>
         <location filename="bootselectiondialog.ui" line="52"/>
         <source>U</source>
-        <translation type="unfinished"></translation>
+        <translation>O</translation>
     </message>
     <message>
         <location filename="bootselectiondialog.ui" line="59"/>
         <source>&amp;Down</source>
-        <translation type="unfinished"></translation>
+        <translation>Nach &amp;unten</translation>
     </message>
     <message>
         <location filename="bootselectiondialog.ui" line="66"/>
         <source>D</source>
-        <translation type="unfinished">D</translation>
+        <translation>U</translation>
     </message>
     <message>
         <location filename="bootselectiondialog.ui" line="95"/>
         <source>BOOT</source>
-        <translation>BOOT</translation>
+        <translation>STARTEN</translation>
     </message>
 </context>
 <context>
@@ -135,12 +135,12 @@
         <location filename="confeditdialog.ui" line="36"/>
         <source>&amp;Edit Options</source>
         <oldsource>Edit Options</oldsource>
-        <translation type="unfinished"></translation>
+        <translation>Optionen &amp;bearbeiten</translation>
     </message>
     <message>
         <location filename="confeditdialog.ui" line="46"/>
         <source>Virtual Keyboard</source>
-        <translation type="unfinished"></translation>
+        <translation>Bildschirmtastatur</translation>
     </message>
     <message>
         <location filename="confeditdialog.cpp" line="104"/>
@@ -150,7 +150,7 @@
     <message>
         <location filename="confeditdialog.cpp" line="105"/>
         <source>Error mounting boot partition</source>
-        <translation>Fehler beim Einbinden der Bootpartition</translation>
+        <translation>Fehler beim Einhängen der Bootpartition</translation>
     </message>
 </context>
 <context>
@@ -158,13 +158,13 @@
     <message>
         <location filename="datetimedialog.ui" line="14"/>
         <source>Set Date &amp; Time</source>
-        <translation type="unfinished">Lege Datum und Uhrzeit fest</translation>
+        <translation>Datum und Uhrzeit einstellen</translation>
     </message>
     <message>
         <location filename="datetimedialog.ui" line="52"/>
         <source>Please set the correct UTC date and time below.</source>
         <oldsource>Please set the correct date and time below.</oldsource>
-        <translation type="unfinished">Bitte lege Datum und Uhrzeit fest</translation>
+        <translation>Bitte Datum und Uhrzeit (UTC) unten richtig einstellen.</translation>
     </message>
 </context>
 <context>
@@ -173,42 +173,42 @@
         <location filename="fullfatthread.cpp" line="39"/>
         <location filename="fullfatthread.cpp" line="47"/>
         <source>Mounting FAT partition</source>
-        <translation type="unfinished">FAT-Partition wird eingebunden</translation>
+        <translation>FAT-Partition wird eingehängt</translation>
     </message>
     <message>
         <location filename="fullfatthread.cpp" line="50"/>
         <source>Error mounting system partition.</source>
-        <translation type="unfinished">Fehler beim Einbinden der Systempartition</translation>
+        <translation>Fehler beim Einhängen der Systempartition.</translation>
     </message>
     <message>
         <location filename="fullfatthread.cpp" line="62"/>
         <source>Error opening %1</source>
-        <translation type="unfinished">Fehler beim Öffnen von %1</translation>
+        <translation>Fehler beim Öffnen von %1</translation>
     </message>
     <message>
         <location filename="fullfatthread.cpp" line="72"/>
         <source>Finish writing to disk (sync)</source>
-        <translation type="unfinished">Schließe Schreibvorgang ab (sync)</translation>
+        <translation>Schreibvorgang wird abgeschlossen (sync)</translation>
     </message>
     <message>
         <location filename="fullfatthread.cpp" line="85"/>
         <source>Error unmounting system partition.</source>
-        <translation type="unfinished">Fehler beim Aushängen der Systempartition.</translation>
+        <translation>Fehler beim Aushängen der Systempartition.</translation>
     </message>
     <message>
         <location filename="fullfatthread.cpp" line="89"/>
         <source>Removing partitions 2,3,4</source>
-        <translation type="unfinished">Entferne Partitionen 2,3,4</translation>
+        <translation>Partitionen 2,3,4 werden entfernt</translation>
     </message>
     <message>
         <location filename="fullfatthread.cpp" line="103"/>
         <source>Resizing FAT partition</source>
-        <translation type="unfinished">Passe Größe der FAT-Partition an</translation>
+        <translation>Größe der FAT-Partition wird geändert</translation>
     </message>
     <message>
         <location filename="fullfatthread.cpp" line="127"/>
         <source>Error resizing existing FAT partition</source>
-        <translation type="unfinished">Fehler bei Größenanpassung der bestehenden FAT-Partition</translation>
+        <translation>Fehler bei Größenanpassung der bestehenden FAT-Partition</translation>
     </message>
 </context>
 <context>
@@ -217,12 +217,12 @@
         <location filename="initdrivethread.cpp" line="53"/>
         <location filename="initdrivethread.cpp" line="84"/>
         <source>Mounting FAT partition</source>
-        <translation>FAT-Partition wird eingebunden</translation>
+        <translation>FAT-Partition wird eingehängt</translation>
     </message>
     <message>
         <location filename="initdrivethread.cpp" line="77"/>
         <source>Formatting settings partition</source>
-        <translation>Formatiere Einstellungspartition</translation>
+        <translation>Einstellungspartition wird formatiert</translation>
     </message>
     <message>
         <location filename="initdrivethread.cpp" line="80"/>
@@ -239,7 +239,7 @@
         <location filename="initdrivethread.cpp" line="194"/>
         <location filename="initdrivethread.cpp" line="393"/>
         <source>Zeroing partition table</source>
-        <translation>Lösche Partitionstabelle</translation>
+        <translation>Partitionstabelle wird gelöscht</translation>
     </message>
     <message>
         <location filename="initdrivethread.cpp" line="197"/>
@@ -253,8 +253,8 @@
 WARNING: This will erase all data on your SD card.</source>
         <oldsource>Would you like PINN to create one for you?
 WARNING: This will erase all data on your SD card</oldsource>
-        <translation type="unfinished">Soll PINN eine für Sie erstellen?
-Achtung: Dies löscht alle Ihre Daten auf der SD-Karte</translation>
+        <translation>Soll PINN eine erstellen?
+Achtung: Dies löscht alle Daten auf dieser SD-Karte.</translation>
     </message>
     <message>
         <location filename="initdrivethread.cpp" line="189"/>
@@ -264,7 +264,7 @@ Achtung: Dies löscht alle Ihre Daten auf der SD-Karte</translation>
     <message>
         <location filename="initdrivethread.cpp" line="202"/>
         <source>Writing new MBR</source>
-        <translation>Schreibe neue Partitionstabelle (MBR)</translation>
+        <translation>Neue Partitionstabelle (MBR) wird geschrieben</translation>
     </message>
     <message>
         <location filename="initdrivethread.cpp" line="210"/>
@@ -275,22 +275,22 @@ Achtung: Dies löscht alle Ihre Daten auf der SD-Karte</translation>
         <location filename="initdrivethread.cpp" line="218"/>
         <source>SD card has now been formatted ready for PINN installation. Please re-copy the PINN files onto the card and reboot</source>
         <oldsource>SD card has now been formatted ready for NOOBS installation. Please re-copy the NOOBS files onto the card and reboot</oldsource>
-        <translation type="unfinished">Die SD-Karte wurde für die Installation von PINN formatiert. Bitte kopieren Sie die PINN-Dateien erneut auf die SD-Karte und starten Sie neu</translation>
+        <translation>Die SD-Karte wurde für die Installation von PINN formatiert. Bitte die PINN-Dateien erneut auf die SD-Karte kopieren und neu starten</translation>
     </message>
     <message>
         <location filename="initdrivethread.cpp" line="223"/>
         <source>SD card has not been formatted correctly. Please reformat using the SD Association Formatting Tool and try again.</source>
-        <translation>Die SD-Karte wurde nicht korrekt formatiert. Bitte formatieren Sie die Karte mit Hilfe des &apos;SD Association Formatting Tool&apos; neu und versuchen es erneut.</translation>
+        <translation>Die SD-Karte wurde nicht korrekt formatiert. Bitte die Karte mit Hilfe des »SD Association Formatting Tool« neu formatieren und es erneut versuchen.</translation>
     </message>
     <message>
         <location filename="initdrivethread.cpp" line="229"/>
         <source>Removing partitions 2,3,4</source>
-        <translation>Entferne Partitionen 2,3,4</translation>
+        <translation>Partitionen 2,3,4 werden entfernt</translation>
     </message>
     <message>
         <location filename="initdrivethread.cpp" line="243"/>
         <source>Resizing FAT partition</source>
-        <translation>Passe Größe der FAT-Partition an</translation>
+        <translation>Größe der FAT-Partition wird angepasst</translation>
     </message>
     <message>
         <location filename="initdrivethread.cpp" line="267"/>
@@ -300,7 +300,7 @@ Achtung: Dies löscht alle Ihre Daten auf der SD-Karte</translation>
     <message>
         <location filename="initdrivethread.cpp" line="273"/>
         <source>Creating extended partition</source>
-        <translation>Erstelle erweiterte Partition</translation>
+        <translation>Erweiterte Partition wird erstellt</translation>
     </message>
     <message>
         <location filename="initdrivethread.cpp" line="307"/>
@@ -310,22 +310,22 @@ Achtung: Dies löscht alle Ihre Daten auf der SD-Karte</translation>
     <message>
         <location filename="initdrivethread.cpp" line="381"/>
         <source>Saving boot files to memory</source>
-        <translation>Speichere die Boot-Dateien</translation>
+        <translation>Boot-Dateien werden auf Karte gespeichert</translation>
     </message>
     <message>
         <location filename="initdrivethread.cpp" line="384"/>
         <source>Error saving boot files to memory. SD card may be damaged.</source>
-        <translation>Fehler beim Speichern der Boot-Dateien. Die SD-Karte ist vielleicht beschädigt.</translation>
+        <translation>Fehler beim Speichern der Boot-Dateien. Die SD-Karte ist möglicherweise beschädigt.</translation>
     </message>
     <message>
         <location filename="initdrivethread.cpp" line="400"/>
         <source>Creating partitions</source>
-        <translation>Partitionen werden erstellt.</translation>
+        <translation>Partitionen werden erstellt</translation>
     </message>
     <message>
         <location filename="initdrivethread.cpp" line="404"/>
         <source>Error partitioning</source>
-        <translation>Fehler beim Partitionieren.</translation>
+        <translation>Fehler beim Partitionieren</translation>
     </message>
     <message>
         <location filename="initdrivethread.cpp" line="408"/>
@@ -340,22 +340,22 @@ Achtung: Dies löscht alle Ihre Daten auf der SD-Karte</translation>
     <message>
         <location filename="initdrivethread.cpp" line="415"/>
         <source>Copying boot files to storage</source>
-        <translation>Boot-Dateien werden auf den Speicher kopiert.</translation>
+        <translation>Boot-Dateien werden auf den Speicher kopiert</translation>
     </message>
     <message>
         <location filename="initdrivethread.cpp" line="510"/>
         <source>Setting disk volume ID</source>
-        <translation>Disk-Volume-ID wird gesetzt.</translation>
+        <translation>Disk-Volume-ID wird gesetzt</translation>
     </message>
     <message>
         <location filename="initdrivethread.cpp" line="87"/>
         <source>Error mounting system partition.</source>
-        <translation>Fehler beim Einbinden der Systempartition</translation>
+        <translation>Fehler beim Einhängen der Systempartition.</translation>
     </message>
     <message>
         <location filename="initdrivethread.cpp" line="92"/>
         <source>Editing cmdline.txt</source>
-        <translation>Bearbeite cmdline.txt</translation>
+        <translation>cmdline.txt wird bearbeitet</translation>
     </message>
     <message>
         <location filename="initdrivethread.cpp" line="102"/>
@@ -365,7 +365,7 @@ Achtung: Dies löscht alle Ihre Daten auf der SD-Karte</translation>
     <message>
         <location filename="initdrivethread.cpp" line="115"/>
         <source>Writing RiscOS blob</source>
-        <translation>Schreibe RiscOS blob</translation>
+        <translation>RiscOS blob wird geschrieben</translation>
     </message>
     <message>
         <location filename="initdrivethread.cpp" line="118"/>
@@ -375,17 +375,17 @@ Achtung: Dies löscht alle Ihre Daten auf der SD-Karte</translation>
     <message>
         <location filename="initdrivethread.cpp" line="125"/>
         <source>Unmounting boot partition</source>
-        <translation>Hänge Boot-Partition aus</translation>
+        <translation>Boot-Partition wird ausgehängt</translation>
     </message>
     <message>
         <location filename="initdrivethread.cpp" line="128"/>
         <source>Finish writing to disk (sync)</source>
-        <translation>Schließe Schreibvorgang ab (sync)</translation>
+        <translation>Schreibvorgang wird abgeschlossen (sync)</translation>
     </message>
     <message>
         <location filename="initdrivethread.cpp" line="138"/>
         <source>Mounting boot partition again</source>
-        <translation>Die Boot-Partition wird erneut eingebunden</translation>
+        <translation>Die Boot-Partition wird erneut eingehängt</translation>
     </message>
     <message>
         <location filename="initdrivethread.cpp" line="149"/>
@@ -412,7 +412,7 @@ Achtung: Dies löscht alle Ihre Daten auf der SD-Karte</translation>
         <location filename="mainwindow.ui" line="74"/>
         <location filename="mainwindow.ui" line="185"/>
         <source>Destination drive:</source>
-        <translation>Ziellaufwerk</translation>
+        <translation>Ziellaufwerk:</translation>
     </message>
     <message>
         <location filename="mainwindow.ui" line="103"/>
@@ -424,7 +424,7 @@ Achtung: Dies löscht alle Ihre Daten auf der SD-Karte</translation>
         <location filename="mainwindow.ui" line="129"/>
         <source>Model</source>
         <oldsource>model</oldsource>
-        <translation type="unfinished"></translation>
+        <translation>Modell</translation>
     </message>
     <message>
         <location filename="mainwindow.ui" line="110"/>
@@ -435,7 +435,7 @@ Achtung: Dies löscht alle Ihre Daten auf der SD-Karte</translation>
     <message>
         <location filename="mainwindow.ui" line="139"/>
         <source>Memory</source>
-        <translation type="unfinished"></translation>
+        <translation>Speicher</translation>
     </message>
     <message>
         <location filename="mainwindow.ui" line="173"/>
@@ -446,7 +446,7 @@ Achtung: Dies löscht alle Ihre Daten auf der SD-Karte</translation>
         <location filename="mainwindow.ui" line="264"/>
         <location filename="mainwindow.ui" line="304"/>
         <source>toolBar</source>
-        <translation>Toolbar</translation>
+        <translation>Symbolleiste</translation>
     </message>
     <message>
         <location filename="mainwindow.ui" line="400"/>
@@ -456,7 +456,7 @@ Achtung: Dies löscht alle Ihre Daten auf der SD-Karte</translation>
     <message>
         <location filename="mainwindow.ui" line="403"/>
         <source>Installs the selected operating system image onto this SD card.</source>
-        <translation>Installiert das ausgewählte Betriebssystem-Image auf die SD-Karte</translation>
+        <translation>Installiert das ausgewählte Betriebssystem-Image auf die SD-Karte.</translation>
     </message>
     <message>
         <location filename="mainwindow.ui" line="406"/>
@@ -496,7 +496,7 @@ Achtung: Dies löscht alle Ihre Daten auf der SD-Karte</translation>
     <message>
         <location filename="mainwindow.ui" line="535"/>
         <source>Downloads the selected operating system image to USB for local installation</source>
-        <translation>Lädt die ausgewählten Betreibssystem-Images auf den USB-Stick zur späteren lokalen Installation.</translation>
+        <translation>Lädt die ausgewählten Betriebssystem-Images auf den USB-Stick für eine spätere lokale Installation</translation>
     </message>
     <message>
         <location filename="mainwindow.ui" line="538"/>
@@ -519,7 +519,7 @@ Achtung: Dies löscht alle Ihre Daten auf der SD-Karte</translation>
         <location filename="mainwindow.ui" line="589"/>
         <source>Replace (c)</source>
         <oldsource>Replace (l)</oldsource>
-        <translation type="unfinished">Ersetzen (1)</translation>
+        <translation>Ersetzen (e)</translation>
     </message>
     <message>
         <location filename="mainwindow.ui" line="592"/>
@@ -527,7 +527,7 @@ Achtung: Dies löscht alle Ihre Daten auf der SD-Karte</translation>
         <location filename="mainwindow.ui" line="688"/>
         <source>C</source>
         <oldsource>L</oldsource>
-        <translation type="unfinished">L</translation>
+        <translation>e</translation>
     </message>
     <message>
         <location filename="mainwindow.ui" line="643"/>
@@ -537,17 +537,17 @@ Achtung: Dies löscht alle Ihre Daten auf der SD-Karte</translation>
     <message>
         <location filename="mainwindow.ui" line="670"/>
         <source>Information about the installed OS</source>
-        <translation>Informationen über das installierte Betriebsystem</translation>
+        <translation>Informationen über das installierte Betriebssystem</translation>
     </message>
     <message>
         <location filename="mainwindow.ui" line="682"/>
         <source>Clear (c)</source>
-        <translation type="unfinished"></translation>
+        <translation>Abwählen (c)</translation>
     </message>
     <message>
         <location filename="mainwindow.ui" line="685"/>
         <source>Clear selection</source>
-        <translation type="unfinished"></translation>
+        <translation>Auswahl abwählen</translation>
     </message>
     <message>
         <location filename="mainwindow.ui" line="697"/>
@@ -557,7 +557,7 @@ Achtung: Dies löscht alle Ihre Daten auf der SD-Karte</translation>
     <message>
         <location filename="mainwindow.ui" line="700"/>
         <source>Set Data &amp; Time</source>
-        <translation>Uhrzeit &amp; Datum festlegen</translation>
+        <translation>Datum und Uhrzeit einstellen</translation>
     </message>
     <message>
         <location filename="mainwindow.ui" line="703"/>
@@ -572,7 +572,7 @@ Achtung: Dies löscht alle Ihre Daten auf der SD-Karte</translation>
     <message>
         <location filename="mainwindow.ui" line="715"/>
         <source>Rename an OS with an alias</source>
-        <translation>Bennene ein Betriebsystem in einen Alias um.</translation>
+        <translation>Ein Betriebssystem mit einem Alias umbenennen</translation>
     </message>
     <message>
         <location filename="mainwindow.ui" line="718"/>
@@ -582,17 +582,17 @@ Achtung: Dies löscht alle Ihre Daten auf der SD-Karte</translation>
     <message>
         <location filename="mainwindow.ui" line="727"/>
         <source>Reload Repos (r)</source>
-        <translation type="unfinished"></translation>
+        <translation>Repos neu laden (r)</translation>
     </message>
     <message>
         <location filename="mainwindow.ui" line="730"/>
         <source>Scans Repositories and reloads lists of new OSes</source>
-        <translation type="unfinished"></translation>
+        <translation>Scannt Repositorys und lädt Listen neuer Betriebssysteme nach</translation>
     </message>
     <message>
         <location filename="mainwindow.ui" line="499"/>
         <source>Wifi (w)</source>
-        <translation>Wifi (w)</translation>
+        <translation>WLAN (w)</translation>
     </message>
     <message>
         <location filename="mainwindow.ui" line="62"/>
@@ -607,7 +607,7 @@ Achtung: Dies löscht alle Ihre Daten auf der SD-Karte</translation>
     <message>
         <location filename="mainwindow.ui" line="520"/>
         <source>Change password</source>
-        <translation>Ändere das Passwort</translation>
+        <translation>Passwort ändern</translation>
     </message>
     <message>
         <location filename="mainwindow.ui" line="523"/>
@@ -622,7 +622,7 @@ Achtung: Dies löscht alle Ihre Daten auf der SD-Karte</translation>
     <message>
         <location filename="mainwindow.ui" line="556"/>
         <source>B</source>
-        <translation type="unfinished">B</translation>
+        <translation>B</translation>
     </message>
     <message>
         <location filename="mainwindow.ui" line="607"/>
@@ -654,7 +654,7 @@ Achtung: Dies löscht alle Ihre Daten auf der SD-Karte</translation>
     <message>
         <location filename="mainwindow.ui" line="451"/>
         <source>Edit config (e)</source>
-        <translation>Einstellungen bearbeiten (e)</translation>
+        <translation>Konfiguration bearbeiten (e)</translation>
     </message>
     <message>
         <location filename="mainwindow.ui" line="454"/>
@@ -669,7 +669,7 @@ Achtung: Dies löscht alle Ihre Daten auf der SD-Karte</translation>
     <message>
         <location filename="mainwindow.ui" line="469"/>
         <source>Opens a web browser displaying the Raspberry Pi Forum.</source>
-        <translation>Öffnet das Raspberry Pi Forum in einem Browser.</translation>
+        <translation>Öffnet das Raspberry-Pi-Forum in einem Browser.</translation>
     </message>
     <message>
         <location filename="mainwindow.ui" line="481"/>
@@ -716,17 +716,17 @@ Achtung: Dies löscht alle Ihre Daten auf der SD-Karte</translation>
         <location filename="mainwindow.cpp" line="4839"/>
         <location filename="mainwindow.cpp" line="4883"/>
         <source>Confirm</source>
-        <translation>Bestätigung</translation>
+        <translation>Bestätigen</translation>
     </message>
     <message>
         <location filename="mainwindow.cpp" line="365"/>
         <source>Setting up SD card</source>
-        <translation>Richte SD-Karte ein</translation>
+        <translation>SD-Karte wird eingerichtet</translation>
     </message>
     <message>
         <location filename="mainwindow.cpp" line="412"/>
         <source>Error mounting settings partition</source>
-        <translation>Fehler beim Einbinden der Einstellungspartition</translation>
+        <translation>Fehler beim Einhängen der Einstellungspartition</translation>
     </message>
     <message>
         <location filename="mainwindow.cpp" line="413"/>
@@ -736,7 +736,7 @@ Achtung: Dies löscht alle Ihre Daten auf der SD-Karte</translation>
     <message>
         <location filename="mainwindow.cpp" line="420"/>
         <source>Reformat failed</source>
-        <translation>Neuformatierung gescheitert</translation>
+        <translation>Neuformatierung fehlgeschlagen</translation>
     </message>
     <message>
         <location filename="mainwindow.cpp" line="420"/>
@@ -746,19 +746,20 @@ Achtung: Dies löscht alle Ihre Daten auf der SD-Karte</translation>
     <message>
         <location filename="mainwindow.cpp" line="677"/>
         <source>Please wait while PINN initialises</source>
-        <translation>Bitte warten Sie, während PINN startet</translation>
+        <translation>Bitte warten während PINN startet</translation>
     </message>
     <message>
         <location filename="mainwindow.cpp" line="1131"/>
         <location filename="mainwindow.cpp" line="4784"/>
         <source> is not available.
 Please provide it locally or connect to the internet.</source>
-        <translation>ist nicht verfügbar. Bitte stelle es lokal zur Verfügung oder verbinde dich mit dem Internet</translation>
+        <translation> ist nicht verfügbar.
+Dies bitte lokal zur Verfügung stellen oder mit dem Internet verbinden.</translation>
     </message>
     <message>
         <location filename="mainwindow.cpp" line="1431"/>
         <source>OS(es) Downloaded Successfully.</source>
-        <translation>Download erfolgreich</translation>
+        <translation>Betriebssystem(e) erfolgreich heruntergeladen.</translation>
     </message>
     <message>
         <location filename="mainwindow.cpp" line="1500"/>
@@ -783,17 +784,17 @@ Please provide it locally or connect to the internet.</source>
     <message>
         <location filename="mainwindow.cpp" line="1640"/>
         <source>HDMI preferred mode</source>
-        <translation>HDMI-Modus (normal)</translation>
+        <translation>HDMI-bevorzugter Modus</translation>
     </message>
     <message>
         <location filename="mainwindow.cpp" line="387"/>
         <source>Waiting for SD card (settings partition)</source>
-        <translation>Warte auf SD-Karte (Einstellungspartition)</translation>
+        <translation>Auf SD-Karte wird gewartet (Einstellungspartition)</translation>
     </message>
     <message>
         <location filename="mainwindow.cpp" line="400"/>
         <source>Mounting settings partition</source>
-        <translation>Binde Einstellungspartition ein</translation>
+        <translation>Einstellungspartition wird eingehängt</translation>
     </message>
     <message>
         <location filename="mainwindow.cpp" line="658"/>
@@ -803,12 +804,12 @@ Please provide it locally or connect to the internet.</source>
     <message>
         <location filename="mainwindow.cpp" line="659"/>
         <source>Archival</source>
-        <translation type="unfinished"></translation>
+        <translation>Archivierung</translation>
     </message>
     <message>
         <location filename="mainwindow.cpp" line="660"/>
         <source>Maintenance</source>
-        <translation type="unfinished"></translation>
+        <translation>Wartung</translation>
     </message>
     <message>
         <location filename="mainwindow.cpp" line="1060"/>
@@ -819,7 +820,7 @@ Please provide it locally or connect to the internet.</source>
         <location filename="mainwindow.cpp" line="1061"/>
         <source>Error: Some OSes are not available:
 </source>
-        <translation>Fehler einige Betriebssysteme sind nicht verfügbar:
+        <translation>Fehler: Einige Betriebssysteme sind nicht verfügbar:
 </translation>
     </message>
     <message>
@@ -831,18 +832,19 @@ Please provide it locally or connect to the internet.</source>
         <location filename="mainwindow.cpp" line="1079"/>
         <location filename="mainwindow.cpp" line="1309"/>
         <source>Warning: incompatible Operating System(s) detected. The following OSes aren&apos;t supported on this revision of Raspberry Pi and may fail to boot or function correctly:</source>
-        <translation>Achtung: inkompatible(s) Betriebssystem(e) gefunden. Die nachfolgenden Betriebssysteme werden von dieser Revision des Raspberry Pi nicht unterstützt und werden möglicherweise nicht korrekt funktionieren oder starten:</translation>
+        <translation>Achtung: Inkompatible(s) Betriebssystem(e) gefunden. Die nachfolgenden Betriebssysteme werden von dieser Revision des Raspberry Pi nicht unterstützt und werden möglicherweise nicht korrekt funktionieren oder starten:</translation>
     </message>
     <message>
         <location filename="mainwindow.cpp" line="322"/>
         <source>RUNINSTALLER - Initialise Drive</source>
-        <translation type="unfinished"></translation>
+        <translation>RUNINSTALLER - Laufwerk initialisieren</translation>
     </message>
     <message>
         <location filename="mainwindow.cpp" line="323"/>
         <source>There are existing OSes installed.
 Are you sure you want to initialise the drive?</source>
-        <translation type="unfinished"></translation>
+        <translation>Es sind bereits Betriebssysteme installiert.
+Sicher, dass das Laufwerk initialisiert werden soll?</translation>
     </message>
     <message>
         <location filename="mainwindow.cpp" line="1070"/>
@@ -850,7 +852,7 @@ Are you sure you want to initialise the drive?</source>
         <source>Warning: Partial USB support. The following OSes can only be executed from USB when it is /dev/sda and may fail to boot or function correctly if that is not the case:
 </source>
         <oldsource>Warning: Partial USB support. The following OSes can only be installed to USB when it is /dev/sda and may fail to boot or function correctly if that is not the case:</oldsource>
-        <translation type="unfinished"></translation>
+        <translation>Warnung: Partielle USB-Unterstützung. Folgenden Betriebssysteme können nur von USB ausgeführt werden, wenn es sich um /dev/sda handelt, und booten oder funktionieren möglicherweise nicht korrekt, wenn dies nicht der Fall ist:</translation>
     </message>
     <message>
         <location filename="mainwindow.cpp" line="1070"/>
@@ -858,12 +860,14 @@ Are you sure you want to initialise the drive?</source>
         <source>
 
 Do you want to continue?</source>
-        <translation type="unfinished"></translation>
+        <translation>
+
+Soll fortgesetzt werden?</translation>
     </message>
     <message>
         <location filename="mainwindow.cpp" line="1146"/>
         <source>ReInstall OSes</source>
-        <translation>Installiere die Betriebssysteme (neu)</translation>
+        <translation>Betriebssystem(e) neu installieren</translation>
     </message>
     <message>
         <location filename="mainwindow.cpp" line="1147"/>
@@ -875,7 +879,7 @@ Do you want to continue?</source>
     <message>
         <location filename="mainwindow.cpp" line="1185"/>
         <source>Warning: this will %1 the selected Operating System(s) on %2. The partitions of the selected OSes will first be erased.</source>
-        <translation type="unfinished"></translation>
+        <translation>Warnung: Damit werden die gewählten Betriebssysteme auf %2 %1. Die Partitionen der gewählten Betriebssysteme werden vorher gelöscht.</translation>
     </message>
     <message>
         <location filename="mainwindow.cpp" line="1299"/>
@@ -885,7 +889,7 @@ Do you want to continue?</source>
     <message>
         <location filename="mainwindow.cpp" line="1386"/>
         <source>The download process will begin shortly.</source>
-        <translation>Der Download beginnt in Kürze</translation>
+        <translation>Der Download beginnt gleich.</translation>
     </message>
     <message>
         <location filename="mainwindow.cpp" line="1434"/>
@@ -898,18 +902,19 @@ Do you want to continue?</source>
 See debug log for details.</source>
         <oldsource>OS(es) Backed up with errors.
 See debug log for details</oldsource>
-        <translation type="unfinished">Betriebssystem(e) nicht fehlerfrei gesichtert. Schaue in das Debug-Log</translation>
+        <translation>Betriebssystem(e) nicht fehlerfrei gesichert.
+Siehe Fehlerprotokoll für weitere Einzelheiten.</translation>
     </message>
     <message>
         <location filename="mainwindow.cpp" line="1450"/>
         <source>OS(es) Backed up Successfully.</source>
-        <translation>Betriebssystem(e) erfolgreich gesichtert</translation>
+        <translation>Betriebssystem(e) erfolgreich gesichert.</translation>
     </message>
     <message>
         <location filename="mainwindow.cpp" line="1452"/>
         <location filename="mainwindow.cpp" line="4987"/>
         <source>Backup OSes</source>
-        <translation>Sichere die Betriebssysteme</translation>
+        <translation>Betriebssysteme sichern</translation>
     </message>
     <message>
         <location filename="mainwindow.cpp" line="1461"/>
@@ -920,37 +925,37 @@ See debug log for details</oldsource>
     <message>
         <location filename="mainwindow.cpp" line="1463"/>
         <source>Installation complete</source>
-        <translation type="unfinished"></translation>
+        <translation>Installation beendet</translation>
     </message>
     <message>
         <location filename="mainwindow.cpp" line="1576"/>
         <source>Abort</source>
-        <translation type="unfinished"></translation>
+        <translation>Abbruch</translation>
     </message>
     <message>
         <location filename="mainwindow.cpp" line="1577"/>
         <source>Discard</source>
-        <translation type="unfinished"></translation>
+        <translation>Verwerfen</translation>
     </message>
     <message>
         <location filename="mainwindow.cpp" line="1578"/>
         <source>Retry</source>
-        <translation type="unfinished"></translation>
+        <translation>Wiederholen</translation>
     </message>
     <message>
         <location filename="mainwindow.cpp" line="1579"/>
         <source>Keep</source>
-        <translation type="unfinished"></translation>
+        <translation>Behalten</translation>
     </message>
     <message>
         <location filename="mainwindow.cpp" line="1603"/>
         <source>Reboot in %1 secs</source>
-        <translation>Neustart in %1 Sekunde(n).</translation>
+        <translation>Neustart in %1 Sekunde(n)</translation>
     </message>
     <message>
         <location filename="mainwindow.cpp" line="1644"/>
         <source>HDMI safe mode</source>
-        <translation>sicherer HDMI-Modus</translation>
+        <translation>Sicherer HDMI-Modus</translation>
     </message>
     <message>
         <location filename="mainwindow.cpp" line="1648"/>
@@ -967,30 +972,30 @@ See debug log for details</oldsource>
         <source>Display mode changed to %1
 Would you like to make this setting permanent?</source>
         <translation>Darstellungsmodus geändert zu %1
-Wollen Sie diese Einstellung dauerhaft speichern?</translation>
+Soll diese Einstellung dauerhaft gespeichert werden?</translation>
     </message>
     <message>
         <location filename="mainwindow.cpp" line="1913"/>
         <source>Wiping SD card</source>
-        <translation>SD-Karte wird zurückgesetzt.</translation>
+        <translation>SD-Karte wird überschrieben</translation>
     </message>
     <message>
         <location filename="mainwindow.cpp" line="1939"/>
         <source>Warning: this will restore your PINN drive to its initial state. All existing data on the drive except PINN will be overwritten, including any OSes that are already installed.</source>
         <oldsource>Warning: this will restore your SD card to its initial state. All existing data on the SD card except PINN will be overwritten, including any OSes that are already installed.</oldsource>
-        <translation>Warnung: Dies wird dein PINN-Laufwerk in seinen Anfangszustand zurücksetzen. Alle existierenden Dateien, inklusive installierten Betriebssystemen, werden gelöscht</translation>
+        <translation>Warnung: Damit wird das PINN-Laufwerk in seinen Initialzustand zurückgesetzt. Außer PINN werden alle Daten auf dem Laufwerk, einschließlich aller installierter Betriebssysteme, überschrieben.</translation>
     </message>
     <message>
         <location filename="mainwindow.cpp" line="1944"/>
         <source>Drive Wiped!</source>
-        <translation>Laufwerk zurückgesetzt!</translation>
+        <translation>Laufwerk überschrieben!</translation>
     </message>
     <message>
         <location filename="mainwindow.cpp" line="2228"/>
         <location filename="mainwindow.cpp" line="2366"/>
         <source>Error downloading distribution list from Internet:
 </source>
-        <translation>Fehler beim Herunterladen der Distributions-Liste aus dem Internet:
+        <translation>Fehler beim Herunterladen der Distributionsliste aus dem Internet:
 </translation>
     </message>
     <message>
@@ -1006,29 +1011,29 @@ Wollen Sie diese Einstellung dauerhaft speichern?</translation>
     <message>
         <location filename="mainwindow.cpp" line="2247"/>
         <source>Error parsing repolist.json downloaded from server</source>
-        <translation type="unfinished">Fehler beim Verarbeiten von repolist.json vom Server.</translation>
+        <translation>Fehler beim Verarbeiten der repolist.json vom Server</translation>
     </message>
     <message>
         <location filename="mainwindow.cpp" line="2873"/>
         <source>Error downloading meta file: </source>
-        <translation>Fehler beim Download einer Meta-Datei:</translation>
+        <translation>Fehler beim Download einer Metadatei:</translation>
     </message>
     <message>
         <location filename="mainwindow.cpp" line="3242"/>
         <location filename="mainwindow.cpp" line="4755"/>
         <location filename="mainwindow.cpp" line="4793"/>
         <source>Replace OSes</source>
-        <translation>Ersetze das Betriebssystem/die Betriebssysteme</translation>
+        <translation>Betriebssystem(e) ersetzen</translation>
     </message>
     <message>
         <location filename="mainwindow.cpp" line="3289"/>
         <source>Resume partial downloads?</source>
-        <translation type="unfinished"></translation>
+        <translation>Partielle Downloads fortsetzen?</translation>
     </message>
     <message>
         <location filename="mainwindow.cpp" line="3290"/>
         <source>Normally select NO, unless your last download was not successful, in which case select YES</source>
-        <translation type="unfinished"></translation>
+        <translation>Normalerweise NEIN wählen, es sei denn, der letzte Download war nicht erfolgreich; in diesem Fall JA wählen</translation>
     </message>
     <message>
         <location filename="mainwindow.cpp" line="3514"/>
@@ -1045,7 +1050,9 @@ Wollen Sie diese Einstellung dauerhaft speichern?</translation>
         <source> MB is available. This is only an estimate. If you continue, the backup may not complete successfully.
 
 Do you want to continue?</source>
-        <translation>MB sind verfügbar. Dies ist nur eine Einschätzung. Wenn du fortfährst wird das Backup eventuell nicht erfolgreich fertiggestellt.</translation>
+        <translation>MB sind verfügbar. Dies ist nur eine Schätzung. Wird fortgesetzt, kann das Backup eventuell nicht erfolgreich fertiggestellt werden.
+
+Soll fortgesetzt werden?</translation>
     </message>
     <message>
         <location filename="mainwindow.cpp" line="3519"/>
@@ -1060,32 +1067,32 @@ Do you want to continue?</source>
     <message>
         <location filename="mainwindow.cpp" line="3526"/>
         <source>Always test your backups before relying on them</source>
-        <translation>Teste deine Backups immer, bevor du dich auf sie verlässt.</translation>
+        <translation>Backups immer testen, bevor sich darauf verlassen wird</translation>
     </message>
     <message>
         <location filename="mainwindow.cpp" line="3576"/>
         <source>Network access is required to use PINN without local images. Please select your wifi network in the next screen.</source>
-        <translation>Internetzugriff wird benötigt, um PINN ohne lokalen Images zu benutzen. Bitte lege dein Wi-Fi Netzwerk auf dem nächsten Bildschirm fest.</translation>
+        <translation>Netzwerkzugriff ist erforderlich, um PINN ohne lokalen Images zu verwenden. Bitte das WLAN-Netzwerk auf der nächsten Seite auswählen.</translation>
     </message>
     <message>
         <location filename="mainwindow.cpp" line="3584"/>
         <source>Wired network access is required to use PINN without local images. Please insert a network cable into the network port.</source>
-        <translation>Internetzugriff per Kabel wird benötigt, um PINN ohne lokalen Images zu benutzen. Bitte stecke ein Netzwerkkabel in den Netzwerkanschluss.</translation>
+        <translation>Kabelgebundenes Netzwerk ist erforderlich, um PINN ohne lokale Images zu verwenden. Bitte ein Netzwerkkabel mit dem Netzwerkanschluss verbinden.</translation>
     </message>
     <message>
         <location filename="mainwindow.cpp" line="3916"/>
         <source>Are you sure you want to reformat the drive &apos;%1&apos; for use with PINN? All existing data on the drive will be deleted!</source>
-        <translation>Bist du sicher, dass du das Laufwerk &apos;%1&apos; für die Benutzung mit PINN neu formatieren willst? Alle vorhanden Daten auf dem Laufwerk werden gelöscht!</translation>
+        <translation>Soll das Laufwerk »%1« wirklich für die Verwendung mit PINN neu formatiert werden? Alle vorhanden Daten auf dem Laufwerk werden gelöscht!</translation>
     </message>
     <message>
         <location filename="mainwindow.cpp" line="4294"/>
         <source>This will erase all content on the device &apos;%s&apos;. Are you sure?</source>
-        <translation>Dies löscht alle Daten auf dem Laufwerk &apos;%s&apos;. Bist du sicher?</translation>
+        <translation>Dies löscht alle Daten auf dem Laufwerk »%s«. Ganz sicher?</translation>
     </message>
     <message>
         <location filename="mainwindow.cpp" line="4296"/>
         <source>Clone SD Card</source>
-        <translation>Klone die SD-Karte</translation>
+        <translation>SD-Karte klonen</translation>
     </message>
     <message>
         <location filename="mainwindow.cpp" line="4298"/>
@@ -1116,7 +1123,7 @@ Do you want to continue?</source>
         <location filename="mainwindow.cpp" line="4448"/>
         <location filename="mainwindow.cpp" line="4549"/>
         <source>PINN Update Check</source>
-        <translation>PINN Update-Check</translation>
+        <translation>PINN Update-Prüfung</translation>
     </message>
     <message>
         <location filename="mainwindow.cpp" line="4448"/>
@@ -1136,12 +1143,12 @@ Do you want to continue?</source>
     <message>
         <location filename="mainwindow.cpp" line="4559"/>
         <source>A new version of PINN is available</source>
-        <translation>Eine neue Version von PINN ist verfügba</translation>
+        <translation>Eine neue Version von PINN ist verfügbar</translation>
     </message>
     <message>
         <location filename="mainwindow.cpp" line="4560"/>
         <source>Do you want to download this version?</source>
-        <translation>Möchten Sie diese Version herunterladen?</translation>
+        <translation>Soll diese Version heruntergeladen werden?</translation>
     </message>
     <message>
         <location filename="mainwindow.cpp" line="4592"/>
@@ -1151,64 +1158,65 @@ Do you want to continue?</source>
     <message>
         <location filename="mainwindow.cpp" line="4592"/>
         <source>Press ESC to cancel</source>
-        <translation>Drücken Sie zum Abbrechen die ESC-Taste</translation>
+        <translation>Zum Abbrechen die ESC-Taste drücken</translation>
     </message>
     <message>
         <location filename="mainwindow.cpp" line="4756"/>
         <source>Error: No OSes selected
 (Do not choose RISC OS or PINN)</source>
-        <translation type="unfinished"></translation>
+        <translation>Fehler: Kein Betriebssystem ausgewählt
+(Bitte nicht RISC oder PINN auswählen)</translation>
     </message>
     <message>
         <location filename="mainwindow.cpp" line="4794"/>
         <source>Warning: No OSes selected
 </source>
-        <translation type="unfinished"></translation>
+        <translation>Warnung: Kein Betriebssystem ausgewählt</translation>
     </message>
     <message>
         <location filename="mainwindow.cpp" line="4840"/>
         <source>Warning: this will backup the selected Operating System(s).</source>
-        <translation type="unfinished"></translation>
+        <translation>Warnung: Damit werden die gewählten Betriebssysteme gesichert (Backup).</translation>
     </message>
     <message>
         <location filename="mainwindow.cpp" line="4884"/>
         <source>Warning: Unsupported Operating System(s) detected. PINN currently cannot backup the following OSes correctly:</source>
-        <translation type="unfinished"></translation>
+        <translation>Warnung: Nicht unterstützte(s) Betriebssystem(e) erkannt. PINN kann gegenwärtig folgende Betriebssysteme nicht korrekt sichern (Backup):</translation>
     </message>
     <message>
         <location filename="mainwindow.cpp" line="2390"/>
         <source>Error parsing list.json downloaded from server</source>
-        <translation>Fehler beim Einlesen der vom Server geladenen list.json</translation>
+        <translation>Fehler beim Verarbeiten der vom Server geladenen list.json</translation>
     </message>
     <message>
         <location filename="mainwindow.cpp" line="1164"/>
         <source>install</source>
-        <translation type="unfinished"></translation>
+        <translation>installieren</translation>
     </message>
     <message>
         <location filename="mainwindow.cpp" line="1167"/>
         <source>reinstall</source>
-        <translation type="unfinished"></translation>
+        <translation>neu installieren</translation>
     </message>
     <message>
         <location filename="mainwindow.cpp" line="1170"/>
         <source>replace</source>
-        <translation type="unfinished"></translation>
+        <translation>ersetzen</translation>
     </message>
     <message>
         <location filename="mainwindow.cpp" line="1180"/>
         <source>USB drive</source>
-        <translation type="unfinished"></translation>
+        <translation>USB-Laufwerk</translation>
     </message>
     <message>
         <location filename="mainwindow.cpp" line="1181"/>
         <source>Warning: this will %1 the selected Operating System(s) to %2. All existing data on the %3 will be deleted.</source>
-        <translation type="unfinished"></translation>
+        <translation>Warnung: Damit werden die ausgewählten Betriebssysteme auf %2 %1. Alle vorhandenen Daten auf %3 werden gelöscht.</translation>
     </message>
     <message>
         <location filename="mainwindow.cpp" line="1276"/>
         <source>The %1 process will begin shortly.</source>
-        <translation type="unfinished"></translation>
+        <translation>Der Prozess %1 beginnt gleich.</translation>
     </message>
     <message>
         <location filename="mainwindow.cpp" line="1429"/>
@@ -1216,7 +1224,8 @@ Do you want to continue?</source>
 See debug log for details.</source>
         <oldsource>OS(es) Downloaded with errors.
 See debug log for details</oldsource>
-        <translation type="unfinished"></translation>
+        <translation>Betriebssystem(e) mit Fehlern heruntergeladen.
+Siehe Fehlerprotokoll für weitere Einzelheiten.</translation>
     </message>
     <message>
         <location filename="mainwindow.cpp" line="1459"/>
@@ -1224,14 +1233,17 @@ See debug log for details</oldsource>
 See debug log for details.</source>
         <oldsource>OS(es) Installed with errors.
 See debug log for details</oldsource>
-        <translation type="unfinished"></translation>
+        <translation>Betriebssystem(e) mit Fehlern installiert.
+Siehe Fehlerprotokoll für weitere Einzelheiten.</translation>
     </message>
     <message>
         <location filename="mainwindow.cpp" line="1945"/>
         <source>Warning: Any installed OSes have been wiped and the drive has been restored to its original size.
 Install and download will no longer work until this drive is re-booted.
 Booting this drive again will re-instate PINN&apos;s partition structure.</source>
-        <translation type="unfinished"></translation>
+        <translation>Warnung: Alle installierten Betriebssysteme wurden gelöscht und das Laufwerk wurde auf seine ursprüngliche Größe zurückgesetzt.
+Installieren und Herunterladen funktionieren nicht mehr, bis dieses Laufwerk neu gebootet wird.
+Ein erneutes Booten dieses Laufwerks stellt die Partitionsstruktur von PINN wieder her.</translation>
     </message>
     <message>
         <location filename="mainwindow.cpp" line="2659"/>
@@ -1248,40 +1260,40 @@ Booting this drive again will re-instate PINN&apos;s partition structure.</sourc
     <message>
         <location filename="mainwindow.cpp" line="2887"/>
         <source>Error downloading meta file</source>
-        <translation>Fehler beim Herunterladen der Meta-Datei</translation>
+        <translation>Fehler beim Herunterladen der Metadatei</translation>
     </message>
     <message>
         <location filename="mainwindow.cpp" line="2898"/>
         <location filename="mainwindow.cpp" line="4463"/>
         <source>Error writing downloaded file to SD card. SD card or file system may be damaged.</source>
-        <translation>Fehler beim Schreiben der heruntergeladenen Datei auf die SD-Karte. Die SD-Karte oder deren Dateisystem könnte fehlerhaft sein.</translation>
+        <translation>Fehler beim Schreiben der heruntergeladenen Datei auf die SD-Karte. Die SD-Karte oder das Dateisystem könnte fehlerhaft sein.</translation>
     </message>
     <message>
         <location filename="mainwindow.cpp" line="3010"/>
         <source>filesize error checking </source>
-        <translation type="unfinished"></translation>
+        <translation>Überprüfung der Dateigröße</translation>
     </message>
     <message>
         <location filename="mainwindow.cpp" line="3243"/>
         <source> has an incompatible number of partitions with </source>
-        <translation type="unfinished"></translation>
+        <translation>hat eine inkompatible Anzahl Partitionen mit </translation>
     </message>
     <message>
         <location filename="mainwindow.cpp" line="3915"/>
         <source>Reformat drive?</source>
-        <translation type="unfinished"></translation>
+        <translation>Laufwerk neu formatieren?</translation>
     </message>
     <message>
         <location filename="mainwindow.cpp" line="1958"/>
         <location filename="mainwindow.cpp" line="3575"/>
         <location filename="mainwindow.cpp" line="3583"/>
         <source>No network access</source>
-        <translation>Kein Netzwerk gefunden</translation>
+        <translation>Kein Netzwerkzugriff</translation>
     </message>
     <message>
         <location filename="mainwindow.cpp" line="1959"/>
         <source>Wired network access is required for this feature. Please insert a network cable into the network port.</source>
-        <translation>Für diese Funktion ist eine kabelgebundene Netzwerkverbindung erforderlich. Bitte stecken Sie ein Netzwerkkabel ein.</translation>
+        <translation>Für diese Funktion ist eine kabelgebundene Netzwerkverbindung erforderlich. Bitte ein Netzwerkkabel einstecken.</translation>
     </message>
 </context>
 <context>
@@ -1289,37 +1301,37 @@ Booting this drive again will re-instate PINN&apos;s partition structure.</sourc
     <message>
         <location filename="multiimagedownloadthread.cpp" line="58"/>
         <source>Finish writing (sync)</source>
-        <translation type="unfinished">Schließe Schreibvorgang ab (sync)</translation>
+        <translation>Schreibvorgang wird abgeschlossen (sync)</translation>
     </message>
     <message>
         <location filename="multiimagedownloadthread.cpp" line="94"/>
         <source>File &apos;%1&apos; does not need downloading</source>
-        <translation type="unfinished"></translation>
+        <translation>Datei »%1« muss nicht heruntergeladen werden</translation>
     </message>
     <message>
         <location filename="multiimagedownloadthread.cpp" line="105"/>
         <source>Downloading %1:%2</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 herunterladen: %2</translation>
     </message>
     <message>
         <location filename="multiimagedownloadthread.cpp" line="143"/>
         <source>Checking %1:%2</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 überprüfen: %2</translation>
     </message>
     <message>
         <location filename="multiimagedownloadthread.cpp" line="153"/>
         <source>Error in checksum</source>
-        <translation type="unfinished"></translation>
+        <translation>Fehler in Prüfsumme</translation>
     </message>
     <message>
         <location filename="multiimagedownloadthread.cpp" line="161"/>
         <source>Error downloading or extracting tarball</source>
-        <translation type="unfinished">Fehler beim Herunterladen oder Extrahieren des TAR-Archivs</translation>
+        <translation>Fehler beim Herunterladen oder Extrahieren des TAR-Archivs</translation>
     </message>
     <message>
         <location filename="multiimagedownloadthread.cpp" line="199"/>
         <source>Finished downloading %1</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 wurde vollständig heruntergeladen</translation>
     </message>
 </context>
 <context>
@@ -1337,12 +1349,12 @@ Booting this drive again will re-instate PINN&apos;s partition structure.</sourc
     <message>
         <location filename="multiimagewritethread.cpp" line="155"/>
         <source>Operating system cannot require a system partition (1,5)</source>
-        <translation>Betriebssystem kann keine Systempartition benötigen (1,2,5) {1,5)?}</translation>
+        <translation>Betriebssystem kann keine Systempartition erfordern (1,5)</translation>
     </message>
     <message>
         <location filename="multiimagewritethread.cpp" line="160"/>
         <source>Operating system cannot claim both primary partitions 2 and 4</source>
-        <translation type="unfinished"></translation>
+        <translation>Das Betriebssystem kann nicht beide primären Partitionen 2 und 4 beanspruchen</translation>
     </message>
     <message>
         <location filename="multiimagewritethread.cpp" line="189"/>
@@ -1352,25 +1364,25 @@ Booting this drive again will re-instate PINN&apos;s partition structure.</sourc
     <message>
         <location filename="multiimagewritethread.cpp" line="447"/>
         <source>Finish writing (sync)</source>
-        <translation>Schließe Schreibvorgang ab (sync)</translation>
+        <translation>Schreibvorgang wird abgeschlossen (sync)</translation>
     </message>
     <message>
         <location filename="multiimagewritethread.cpp" line="738"/>
         <source>File &apos;%1&apos; does not exist</source>
-        <translation>Datei &apos;%1&apos; existiert nicht</translation>
+        <translation>Datei »%1« existiert nicht</translation>
     </message>
     <message>
         <location filename="multiimagewritethread.cpp" line="778"/>
         <location filename="multiimagewritethread.cpp" line="785"/>
         <source>%1: Writing OS image</source>
         <oldsource>Writing image</oldsource>
-        <translation>%1: Schreibe Betriebssystem-Image</translation>
+        <translation>%1: Betriebssystem-Image wird geschrieben</translation>
     </message>
     <message>
         <location filename="multiimagewritethread.cpp" line="801"/>
         <source>%1: Mounting file system</source>
         <oldsource>Mounting file system</oldsource>
-        <translation>%1: Binde Dateisystem ein</translation>
+        <translation>%1: Dateisystem wird eingehängt</translation>
     </message>
     <message>
         <location filename="multiimagewritethread.cpp" line="804"/>
@@ -1379,12 +1391,12 @@ Booting this drive again will re-instate PINN&apos;s partition structure.</sourc
         <location filename="multiimagewritethread.cpp" line="1107"/>
         <source>%1: Error mounting file system</source>
         <oldsource>Error mounting file system</oldsource>
-        <translation>%1: Fehler beim Einbinden des Dateisystems</translation>
+        <translation>%1: Fehler beim Einhängen des Dateisystems</translation>
     </message>
     <message>
         <location filename="multiimagewritethread.cpp" line="792"/>
         <source>%1: Creating filesystem (%2)</source>
-        <translation>%1: Erstelle Dateisystem (%2)</translation>
+        <translation>%1: Dateisystem wird erstellt (%2)</translation>
     </message>
     <message>
         <location filename="multiimagewritethread.cpp" line="110"/>
@@ -1404,12 +1416,12 @@ Booting this drive again will re-instate PINN&apos;s partition structure.</sourc
     <message>
         <location filename="multiimagewritethread.cpp" line="218"/>
         <source>Cannot boot partitions &gt; 62. Reduce the number of OSes</source>
-        <translation type="unfinished"></translation>
+        <translation>Partitionen &gt; 62 können nicht gebootet werden. Bitte die Anzahl der Betriebssysteme reduzieren</translation>
     </message>
     <message>
         <location filename="multiimagewritethread.cpp" line="240"/>
         <source>Cannot boot partitions &gt; #62. Reduce the number of OSes</source>
-        <translation type="unfinished"></translation>
+        <translation>Partitionen &gt; #62 können nicht gebootet werden. Bitte die Anzahl der Betriebssysteme reduzieren</translation>
     </message>
     <message>
         <location filename="multiimagewritethread.cpp" line="269"/>
@@ -1419,34 +1431,35 @@ Booting this drive again will re-instate PINN&apos;s partition structure.</sourc
     <message>
         <location filename="multiimagewritethread.cpp" line="329"/>
         <source>Writing partition table</source>
-        <translation>Schreibe Partitionstabelle</translation>
+        <translation>Partitionstabelle wird geschrieben</translation>
     </message>
     <message>
         <location filename="multiimagewritethread.cpp" line="344"/>
         <source>Writing boot partition table</source>
-        <translation type="unfinished"></translation>
+        <translation>Boot-Partitionstabelle (MBR) wird geschrieben</translation>
     </message>
     <message>
         <location filename="multiimagewritethread.cpp" line="334"/>
         <location filename="multiimagewritethread.cpp" line="350"/>
         <source>Zero&apos;ing start of each partition</source>
-        <translation>Lösche Beginn jeder Partition</translation>
+        <translation>Beginn jeder Partition wird mit Null überschrieben</translation>
     </message>
     <message>
         <location filename="multiimagewritethread.cpp" line="395"/>
         <source>.
 Partition not big enough for new image.</source>
-        <translation type="unfinished"></translation>
+        <translation>.
+Partition ist für das neue Image nicht groß genug.</translation>
     </message>
     <message>
         <location filename="multiimagewritethread.cpp" line="395"/>
         <source>Cannot Reinstall/Replace </source>
-        <translation type="unfinished"></translation>
+        <translation>Fehler bei Neuinstallation bzw. beim Ersetzen</translation>
     </message>
     <message>
         <location filename="multiimagewritethread.cpp" line="441"/>
         <source>Operation cancelled by user</source>
-        <translation type="unfinished"></translation>
+        <translation>Vorgang durch Anwender abgebrochen</translation>
     </message>
     <message>
         <location filename="multiimagewritethread.cpp" line="468"/>
@@ -1461,36 +1474,36 @@ Partition not big enough for new image.</source>
     <message>
         <location filename="multiimagewritethread.cpp" line="766"/>
         <source>OS: &apos;%1&apos; needs a partition label of &apos;%2&apos; which is not available</source>
-        <translation type="unfinished"></translation>
+        <translation>Betriebssystem: »%1« benötigt ein Partitionslabel mit »%2«, das nicht verfügbar ist</translation>
     </message>
     <message>
         <location filename="multiimagewritethread.cpp" line="809"/>
         <source>%1: Downloading and extracting filesystem</source>
-        <translation>%1: Lade Dateisystem herunter und entpacke</translation>
+        <translation>%1: Dateisystem wird heruntergeladen und entpackt</translation>
     </message>
     <message>
         <location filename="multiimagewritethread.cpp" line="811"/>
         <source>%1: Extracting filesystem</source>
         <oldsource>%1 Extracting filesystem</oldsource>
-        <translation>%1: Entpacke Dateisystem</translation>
+        <translation>%1: Dateisystem wird entpackt</translation>
     </message>
     <message>
         <location filename="multiimagewritethread.cpp" line="820"/>
         <source>Syncing Filesystem</source>
-        <translation type="unfinished"></translation>
+        <translation>Dateisystem wird synchronisiert</translation>
     </message>
     <message>
         <location filename="multiimagewritethread.cpp" line="838"/>
         <location filename="multiimagewritethread.cpp" line="993"/>
         <source>%1: Mounting FAT partition</source>
         <oldsource>Mouning FAT partition</oldsource>
-        <translation>%1: Binde FAT-Partition ein</translation>
+        <translation>%1: FAT-Partition eingehängt</translation>
     </message>
     <message>
         <location filename="multiimagewritethread.cpp" line="845"/>
         <source>%1: Creating os_config.json</source>
         <oldsource>Creating os_config.json</oldsource>
-        <translation>%1: Erstelle os_config.json</translation>
+        <translation>%1: os_config.json wird erstellt</translation>
     </message>
     <message>
         <location filename="multiimagewritethread.cpp" line="878"/>
@@ -1501,31 +1514,31 @@ Partition not big enough for new image.</source>
     <message>
         <location filename="multiimagewritethread.cpp" line="899"/>
         <source>Error in checksum for partition_setup.sh</source>
-        <translation type="unfinished"></translation>
+        <translation>Fehler in Prüfsumme für partition_setup.sh</translation>
     </message>
     <message>
         <location filename="multiimagewritethread.cpp" line="906"/>
         <source>%1: Running partition setup script</source>
         <oldsource>Running partition setup script</oldsource>
-        <translation>%1: Führe Skript für Partionserstellung aus</translation>
+        <translation>%1: Skript für Partitionserstellung wird ausgeführt</translation>
     </message>
     <message>
         <location filename="multiimagewritethread.cpp" line="963"/>
         <source>%1: Error executing partition setup script</source>
         <oldsource>Error executing partition setup script</oldsource>
-        <translation>%1: Fehler beim Ausführen des Skripts für Partionserstellung</translation>
+        <translation>%1: Fehler beim Ausführen des Skripts für Partitionserstellung</translation>
     </message>
     <message>
         <location filename="multiimagewritethread.cpp" line="980"/>
         <source>%1: Configuring flavour</source>
-        <translation type="unfinished"></translation>
+        <translation>%1: Variante wird konfiguriert</translation>
     </message>
     <message>
         <location filename="multiimagewritethread.cpp" line="970"/>
         <location filename="multiimagewritethread.cpp" line="1001"/>
         <source>%1: Unmounting FAT partition</source>
         <oldsource>%1: Patching BCD file</oldsource>
-        <translation>%1: Passe BCD-Datei an</translation>
+        <translation>%1: FAT-Partition wird ausgehängt</translation>
     </message>
     <message>
         <location filename="multiimagewritethread.cpp" line="973"/>
@@ -1545,31 +1558,31 @@ Partition not big enough for new image.</source>
         <location filename="multiimagewritethread.cpp" line="1697"/>
         <source>Unknown compression format file extension. Expecting .lzo, .gz, .xz, .bz2 or .zip.</source>
         <oldsource>Unknown compression format file extension. Expecting .lzo, .gz, .xz, .bz2 or .zip</oldsource>
-        <translation type="unfinished">Unbekanntes Kompressionsformat in Dateierweiterung. Erwarte .lzo, .gz, .xz, .bz2 oder .zip</translation>
+        <translation>Unbekanntes Kompressionsformat in Dateierweiterung. .Es wird lzo, .gz, .xz, .bz2 oder .zip erwartet.</translation>
     </message>
     <message>
         <location filename="multiimagewritethread.cpp" line="1527"/>
         <location filename="multiimagewritethread.cpp" line="1635"/>
         <location filename="multiimagewritethread.cpp" line="1728"/>
         <source>An incorrect file checksum has been detected in %1</source>
-        <translation type="unfinished"></translation>
+        <translation>In %1 wurde eine falsche Dateiprüfsumme entdeckt</translation>
     </message>
     <message>
         <location filename="multiimagewritethread.cpp" line="1528"/>
         <location filename="multiimagewritethread.cpp" line="1639"/>
         <location filename="multiimagewritethread.cpp" line="1732"/>
         <source>Checksum error</source>
-        <translation type="unfinished"></translation>
+        <translation>Prüfsummenfehler</translation>
     </message>
     <message>
         <location filename="multiimagewritethread.cpp" line="1538"/>
         <source>Checksum OK</source>
-        <translation type="unfinished"></translation>
+        <translation>Prüfsumme OK</translation>
     </message>
     <message>
         <location filename="multiimagewritethread.cpp" line="1541"/>
         <source>Finished downloading</source>
-        <translation type="unfinished"></translation>
+        <translation>Download beendet</translation>
     </message>
     <message>
         <location filename="multiimagewritethread.cpp" line="1649"/>
@@ -1583,516 +1596,516 @@ Partition not big enough for new image.</source>
     <message>
         <location filename="optionsdialog.ui" line="14"/>
         <source>PINN Options</source>
-        <translation type="unfinished"></translation>
+        <translation>PINN Optionen</translation>
     </message>
     <message>
         <location filename="optionsdialog.ui" line="35"/>
         <source>Installation</source>
-        <translation type="unfinished"></translation>
+        <translation>Installation</translation>
     </message>
     <message>
         <location filename="optionsdialog.ui" line="43"/>
         <source>PREVENTS any noobsconfig customisations from being applied to an OS on installation</source>
-        <translation type="unfinished"></translation>
+        <translation>VERHINDERT, dass jegliche noobsconfig-Anpassungen bei der Installation auf ein Betriebssystem angewendet werden</translation>
     </message>
     <message>
         <location filename="optionsdialog.ui" line="46"/>
         <source>noobs&amp;config</source>
         <oldsource>noobsconfig</oldsource>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="optionsdialog.ui" line="53"/>
         <source>Reserve some space on PINN&apos;s partition (MB)</source>
-        <translation type="unfinished"></translation>
+        <translation>Ein Speicherbereich auf der PINN-Partition reservieren (MB)</translation>
     </message>
     <message>
         <location filename="optionsdialog.ui" line="56"/>
         <source>re&amp;serve=</source>
         <oldsource>reserve=</oldsource>
-        <translation type="unfinished"></translation>
+        <translation>Re&amp;serve=</translation>
     </message>
     <message>
         <location filename="optionsdialog.ui" line="66"/>
         <location filename="optionsdialog.ui" line="79"/>
         <source>Specifies a path or URL where the noobsconfig customisation files can be found (rather than being in /os/&amp;lt;distro&amp;gt;/)</source>
-        <translation type="unfinished"></translation>
+        <translation>Gibt eine Pfad oder eine URL an, wo die noobsconfig-Anpassungsdateien zu finden sind (und nicht in /os/&amp;lt;distro&amp;gt;/)</translation>
     </message>
     <message>
         <location filename="optionsdialog.ui" line="86"/>
         <source>Amount of space to reserve (MB) on PINN&apos;s partition</source>
-        <translation type="unfinished"></translation>
+        <translation>Zu reservierender Speicherplatz (MB) auf der PINN-Partition</translation>
     </message>
     <message>
         <location filename="optionsdialog.ui" line="93"/>
         <source>Selecting this will erase all of your OSes</source>
-        <translation type="unfinished"></translation>
+        <translation>Bei Auswahl dieser Option werden alle vorhandenen Betriebssysteme gelöscht</translation>
     </message>
     <message>
         <location filename="optionsdialog.ui" line="103"/>
         <source>Prevents PINN from checking for self updates</source>
-        <translation type="unfinished"></translation>
+        <translation>Verhindert, dass PINN nach Selbstaktualisierungen sucht</translation>
     </message>
     <message>
         <location filename="optionsdialog.ui" line="113"/>
         <source>Force PINN to self-update whenever a new version is detected</source>
-        <translation type="unfinished"></translation>
+        <translation>PINN zur Selbstaktualisierung zwingen, sobald eine neue Version ermittelt wird</translation>
     </message>
     <message>
         <location filename="optionsdialog.ui" line="123"/>
         <source>Selects all OSes where the most recent one is on the SD card</source>
         <oldsource>DO not update the firmware of old OSes on installation</oldsource>
-        <translation type="unfinished"></translation>
+        <translation>Wählt alle Betriebssysteme aus, deren aktuellstes sich auf der SD-Karte befindet</translation>
     </message>
     <message>
         <location filename="optionsdialog.ui" line="133"/>
         <source>Selects all OSes where the most recent one is on a local USB drive</source>
         <oldsource> Selects all OSes where the most recent one is on a local USB drive</oldsource>
-        <translation type="unfinished"></translation>
+        <translation>Wählt alle Betriebssysteme aus, deren aktuellstes sich auf einem lokalen USB-Laufwerk befindet</translation>
     </message>
     <message>
         <location filename="optionsdialog.ui" line="143"/>
         <source>Selects all OSes where the most recent one is on remote repositories.</source>
-        <translation type="unfinished"></translation>
+        <translation>Wählt alle Betriebssysteme aus, deren aktuellstes sich auf entfernten Repositorys befindet.</translation>
     </message>
     <message>
         <location filename="optionsdialog.ui" line="153"/>
         <source>Ensures all installed OSes are selected again.</source>
-        <translation type="unfinished"></translation>
+        <translation>Stellt sicher, dass alle installierten Betriebssysteme wieder ausgewählt werden.</translation>
     </message>
     <message>
         <location filename="optionsdialog.ui" line="163"/>
         <source>Waits for all OSes on the SD card to be listed</source>
-        <translation type="unfinished"></translation>
+        <translation>Wartet darauf, dass alle Betriebssysteme auf der SD-Karte aufgelistet werden</translation>
     </message>
     <message>
         <location filename="optionsdialog.ui" line="173"/>
         <source>Waits for all OSes on local USBs to be listed</source>
         <oldsource> Waits for all OSes on local USBs to be listed</oldsource>
-        <translation type="unfinished"></translation>
+        <translation>Wartet darauf, dass alle Betriebssysteme auf lokalen USB-Laufwerken aufgelistet werden</translation>
     </message>
     <message>
         <location filename="optionsdialog.ui" line="183"/>
         <source>Waits for all OS lists to be downloaded from the internet before checking the list of OSes</source>
-        <translation type="unfinished"></translation>
+        <translation>Wartet, bis alle Betriebssystemlisten aus dem Internet heruntergeladen sind, bevor die Liste der Betriebssysteme überprüft wird</translation>
     </message>
     <message>
         <location filename="optionsdialog.ui" line="193"/>
         <source>Waits for OSes from all sources to be listed</source>
         <oldsource> Waits for OSes from all sources to be listed</oldsource>
-        <translation type="unfinished"></translation>
+        <translation>Wartet darauf, dass die Betriebssysteme aus allen Quellen aufgelistet werden</translation>
     </message>
     <message>
         <location filename="optionsdialog.ui" line="203"/>
         <source>The list of OSes that will be selected at startup</source>
-        <translation type="unfinished"></translation>
+        <translation>Die Liste der Betriebssysteme, die beim Starten ausgewählt werden</translation>
     </message>
     <message>
         <location filename="optionsdialog.ui" line="210"/>
         <source>Reserve an ADDITIONAL amount of space</source>
-        <translation type="unfinished"></translation>
+        <translation>Eine ZUSÄTZLICHE Menge des Speicherplatzes reservieren</translation>
     </message>
     <message>
         <location filename="optionsdialog.ui" line="213"/>
         <source>+</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="optionsdialog.ui" line="220"/>
         <source>Automatically reinstalls any selected OSes if newer versions exist</source>
-        <translation type="unfinished"></translation>
+        <translation>Es werden alle ausgewählten Betriebssysteme automatisch neu installiert, wenn neuere Versionen vorhanden sind</translation>
     </message>
     <message>
         <location filename="optionsdialog.ui" line="230"/>
         <source>Allows a single or multiple OSes to be installed automatically, useful during headless installs. </source>
-        <translation type="unfinished"></translation>
+        <translation>Erlaubt die automatische Installation eines oder mehrerer Betriebssysteme, nützlich bei Headless-Installationen.</translation>
     </message>
     <message>
         <location filename="optionsdialog.ui" line="253"/>
         <source>Source</source>
-        <translation type="unfinished"></translation>
+        <translation>Quelle</translation>
     </message>
     <message>
         <location filename="optionsdialog.ui" line="261"/>
         <source>Prevents the default RaspberryPi Foundation repository from being used.</source>
-        <translation type="unfinished"></translation>
+        <translation>Verhindert, dass das Standard-Repository der RaspberryPi Foundation verwendet wird.</translation>
     </message>
     <message>
         <location filename="optionsdialog.ui" line="271"/>
         <source>Prevents OSes stored on local USB memory devices from being used.</source>
-        <translation type="unfinished"></translation>
+        <translation>Verhindert, dass Betriebssysteme verwendet werden, die auf lokalen USB-Speichergeräten gespeichert sind.</translation>
     </message>
     <message>
         <location filename="optionsdialog.ui" line="281"/>
         <source>Prevent OSes stored on the SD card from being used.</source>
-        <translation type="unfinished"></translation>
+        <translation>Verhindert, dass Betriebssysteme verwendet werden, die auf SD-Karten gespeichert sind.</translation>
     </message>
     <message>
         <location filename="optionsdialog.ui" line="291"/>
         <source>Shows all available installable OSes, whether they are suitable for the current model of Pi or not. Useful for preparing SD cards to be used in other RPis.</source>
-        <translation type="unfinished"></translation>
+        <translation>Zeigt alle verfügbaren installierbaren Betriebssysteme an, egal ob sie für das aktuelle Pi-Modell geeignet sind oder nicht. Nützlich für die Vorbereitung von SD-Karten, die in anderen RPis verwendet werden sollen.</translation>
     </message>
     <message>
         <location filename="optionsdialog.ui" line="301"/>
         <location filename="optionsdialog.ui" line="327"/>
         <source>Provides the URL of a repo_list.json file that contains a list of URLs to other os-list_v3.json files. This allows easy remote management of Internet repositories.</source>
-        <translation type="unfinished"></translation>
+        <translation>Gibt die URL einer repo_list.json-Datei an, die eine Liste von URLs zu anderen os-list_v3.json-Dateien enthält. Dies ermöglicht eine einfache Fernverwaltung von Internet-Repositorys.</translation>
     </message>
     <message>
         <location filename="optionsdialog.ui" line="314"/>
         <location filename="optionsdialog.ui" line="347"/>
         <source>Similar to alt_image_source but it matches the NOOBS method of specifying a list of additional respositories as a space separated quoted string.</source>
         <oldsource> Similar to alt_image_source but it matches the NOOBS method of specifying a list of additional respositories as a space separated quoted string.</oldsource>
-        <translation type="unfinished"></translation>
+        <translation>Ähnlich zu alt_image_source, entspricht jedoch der NOOBS-Methode, bei der eine Liste zusätzlicher Speicherorte in Form einer durch Leerzeichen getrennten und in Anführungszeichen gesetzten Zeichenkette angegeben wird.</translation>
     </message>
     <message>
         <location filename="optionsdialog.ui" line="334"/>
         <location filename="optionsdialog.ui" line="354"/>
         <source>: Provides the URL of an additional os_list_v3.json file indicating the location of other OSes that can be downloaded from the Internet. Multiple instances of this option can be used.</source>
-        <translation type="unfinished"></translation>
+        <translation>: Gibt die URL einer zusätzlichen os_list_v3.json-Datei an, die den Ort anderer Betriebssysteme angibt, die aus dem Internet heruntergeladen werden können. Es können mehrere Instanzen dieser Option verwendet werden.</translation>
     </message>
     <message>
         <location filename="optionsdialog.ui" line="364"/>
         <source>Booting</source>
-        <translation type="unfinished"></translation>
+        <translation>Booten</translation>
     </message>
     <message>
         <location filename="optionsdialog.ui" line="372"/>
         <location filename="optionsdialog.ui" line="428"/>
         <source>When used in conjunction with forcetrigger it sets a maximum timeout period in seconds for the recovery menu to be displayed before continuing to the boot selection dialog and potentially selecting a default OS to boot.</source>
         <oldsource> When used in conjunction with forcetrigger it sets a maximum timeout period in seconds for the recovery menu to be displayed before continuing to the boot selection dialog and potentially selecting a default OS to boot.</oldsource>
-        <translation type="unfinished"></translation>
+        <translation>In Verbindung mit forcetrigger wird eine maximale Zeitspanne in Sekunden festgelegt, für dier das Wiederherstellungsmenü angezeigt wird, bevor das Fenster für das Fenster der Boot-Auswahl erscheint und gegebenenfalls ein Standardbetriebssystem zum Booten ausgewählt wird.</translation>
     </message>
     <message>
         <location filename="optionsdialog.ui" line="385"/>
         <source>Forces the PINN interface to be entered on startup (as if the shift key had been pressed). This is very useful when using a VNC connection.</source>
-        <translation type="unfinished"></translation>
+        <translation>Erzwingt die Anzeige der PINN-Oberfläche beim Starten (als ob die Umschalttaste gedrückt worden wäre). Dies ist sehr nützlich bei der Verwendung einer VNC-Verbindung.</translation>
     </message>
     <message>
         <location filename="optionsdialog.ui" line="395"/>
         <source>Forces Recovery Mode to be entered on boot if GPIO pin 3 on header P1 is connected to GND (pin 25).</source>
-        <translation type="unfinished"></translation>
+        <translation>Erzwingt den Start in den Wiederherstellungsmodus, wenn GPIO-Pin 3 an der Stiftleiste P1 mit GND (Pin 25) verbunden ist.</translation>
     </message>
     <message>
         <location filename="optionsdialog.ui" line="405"/>
         <location filename="optionsdialog.ui" line="435"/>
         <source>This setting allows the network timeout to be specified in seconds, especially for networks that take longer to establish.</source>
         <oldsource> This setting allows the network timeout to be specified in seconds, especially for networks that take longer to establish.</oldsource>
-        <translation type="unfinished"></translation>
+        <translation>Mit dieser Einstellung kann die Netzwerkzeitüberschreitung in Sekunden angegeben werden, insbesondere für Netzwerke, die beim Aufbau länger brauchen.</translation>
     </message>
     <message>
         <location filename="optionsdialog.ui" line="418"/>
         <source>Prevents a SHIFT keypress from entering Recovery Mode on boot (maybe you have a problematic keyboard which is erroneously triggering every time you boot)</source>
         <oldsource>Prevents a SHIFT keypress from entering Recovery Mode on boot (maybe you have a problematic keyboard which is erroneously triggering every time you boot)</oldsource>
-        <translation type="unfinished"></translation>
+        <translation>Verhindert, dass ein Tastendruck auf die UMSCHALTTASTE beim Booten den Wiederherstellungsmodus aktiviert (vielleicht wird eine fehlerhafte Tastatur verwendet, die bei jedem Booten irrtümlich ausgelöst wird)</translation>
     </message>
     <message>
         <location filename="optionsdialog.ui" line="445"/>
         <source>Interface</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="optionsdialog.ui" line="456"/>
         <source>Uses a VNC network connection to control PINN instead of any locally attached keyboard, mouse and display. When this is used, any local display will remain blank.</source>
-        <translation type="unfinished"></translation>
+        <translation>Verwendet eine VNC-Netzwerkverbindung zur Steuerung von PINN anstelle einer lokal angeschlossenen Tastatur, Maus und Bildschirm. Wird dies verwendet, bleibt ein lokaler Bildschirm ohne Anzeige.</translation>
     </message>
     <message>
         <location filename="optionsdialog.ui" line="466"/>
         <source>Uses a VNC network connection to control PINN. However, unlike vncinstall, any locally attached keyboard and mouse will still be active and the display will be duplicated to the local screen and the VNC connection.</source>
         <oldsource>Uses a VNC network connection to control PINN. However, unlike vncinstall, any locally attached keyboard and mouse will still be active and the display will be duplicated to the local screen and the VNC connection.</oldsource>
-        <translation type="unfinished"></translation>
+        <translation>Verwendet eine VNC-Netzwerkverbindung zur Steuerung von PINN. Im Gegensatz zu vncinstall sind jedoch alle lokal angeschlossenen Tastaturen und Mäuse weiterhin aktiv und die Anzeige wird auf den lokalen Bildschirm und die VNC-Verbindung dupliziert.</translation>
     </message>
     <message>
         <location filename="optionsdialog.ui" line="476"/>
         <source>Enables an SSH connection to the rescueshell in PINN. It cannot be used to control PINN, but having a shell is very useful to perform remote maintenance on any of the SD card partitions.</source>
         <oldsource>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Enables an SSH connection to the rescueshell in PINN. It cannot be used to control PINN, but having a shell is very useful to perform remote maintenance on any of the SD card partitions.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</oldsource>
-        <translation type="unfinished"></translation>
+        <translation>Ermöglicht eine SSH-Verbindung zur Rescueshell in PINN. Sie kann nicht zur Steuerung von PINN verwendet werden, aber eine Shell ist sehr nützlich, um Fernwartung auf einer der SD-Kartenpartitionen durchzuführen.</translation>
     </message>
     <message>
         <location filename="optionsdialog.ui" line="486"/>
         <source>This option causes a local command shell to be opened when PINN is booted. When the shell is exited, PINN will then be booted as normal.</source>
-        <translation type="unfinished"></translation>
+        <translation>Diese Option bewirkt, dass beim Booten von PINN eine lokale Kommandozeile geöffnet wird. Wenn die Kommandozeile beendet wird, bootet PINN wie gewohnt.</translation>
     </message>
     <message>
         <location filename="optionsdialog.ui" line="496"/>
         <source>Prevents safemode being entered if you have external hardware that pulls pin 5 low.</source>
-        <translation type="unfinished"></translation>
+        <translation>Verhindert den Wechsel in den Safemode, wenn eine externe Hardware vorhanden ist, die Pin 5 auf niedrig schaltet.</translation>
     </message>
     <message>
         <location filename="optionsdialog.ui" line="506"/>
         <source>A special boot feature to swap the priority of the DSI and HDMI video outputs, allowing an OS to give priority to a HDMI screen if attached.</source>
-        <translation type="unfinished"></translation>
+        <translation>Ein spezielles Boot-Feature, um die Priorität der DSI- und HDMI-Videoausgänge zu tauschen, so dass ein Betriebssystem einem HDMI-Bildschirm den Vorrang geben kann, wenn er angeschlossen ist.</translation>
     </message>
     <message>
         <location filename="optionsdialog.ui" line="516"/>
         <source>Prevents the list of OSes from being grouped into categories.</source>
-        <translation type="unfinished"></translation>
+        <translation>Verhindert, dass die Liste der Betriebssysteme in Kategorien gruppiert wird.</translation>
     </message>
     <message>
         <location filename="optionsdialog.ui" line="526"/>
         <source>Prevents the cursor from being shown on the boot selection dialog (requested for touchscreen devices)</source>
-        <translation type="unfinished"></translation>
+        <translation>Verhindert, dass der Mauszeiger im Boot-Auswahldialog angezeigt wird (gewünscht für Geräten mit Touchscreen)</translation>
     </message>
     <message>
         <location filename="optionsdialog.ui" line="536"/>
         <source>Causes a customised wallpaper.jpg or wallpaper.png file to be resized to fill the entire desktop</source>
-        <translation type="unfinished"></translation>
+        <translation>Bewirkt, dass die Größe einer eigenen Datei wallpaper.jpg oder wallpaper.png so angepasst wird, dass sie den gesamten Desktop ausfüllt</translation>
     </message>
     <message>
         <location filename="optionsdialog.ui" line="546"/>
         <location filename="optionsdialog.ui" line="598"/>
         <source>Sets one of 4 simple display modes: 0=HDMI preferred, 1=HDMI safe, 2= PAL 4:3, 3=NTSC  4:3</source>
-        <translation type="unfinished"></translation>
+        <translation>Legt einen von 4 einfachen Anzeigemodi fest: 0=HDMI bevorzugt, 1=HDMI sicher, 2=PAL 4:3, 3=NTSC 4:3</translation>
     </message>
     <message>
         <location filename="optionsdialog.ui" line="559"/>
         <location filename="optionsdialog.ui" line="630"/>
         <source>Changes the style of the windows</source>
-        <translation type="unfinished"></translation>
+        <translation>Ändert den Fensterstil</translation>
     </message>
     <message>
         <location filename="optionsdialog.ui" line="572"/>
         <location filename="optionsdialog.ui" line="657"/>
         <source>Changes the default timeout allowed before an OS is booted without any selection. </source>
-        <translation type="unfinished"></translation>
+        <translation>Ändert die Zeitspanne, die standardmäßig verstreichen darf, bevor ein Betriebssystem ohne Auswahl gebootet wird. </translation>
     </message>
     <message>
         <location filename="optionsdialog.ui" line="585"/>
         <location filename="optionsdialog.ui" line="664"/>
         <source>To change the background colour for the screen and most windows, add background=r,g,b, where 0,0,0 is black and 255,255,255 is white. I suggest to use values above 127.</source>
-        <translation type="unfinished"></translation>
+        <translation>Um die Hintergrundfarbe für den Bildschirm und die meisten Fenster zu ändern, background=r,g,b hinzufügen, wobei 0,0,0 schwarz und 255,255,255 weiß ist. Ich empfehle, Werte über 127 zu verwenden.</translation>
     </message>
     <message>
         <location filename="optionsdialog.ui" line="681"/>
         <source>Virtual Keyboard</source>
-        <translation type="unfinished"></translation>
+        <translation>Bildschirmtastatur</translation>
     </message>
     <message>
         <location filename="optionsdialog.ui" line="69"/>
         <source>&amp;configpath=</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="optionsdialog.ui" line="96"/>
         <source>&amp;runinstaller</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="optionsdialog.ui" line="106"/>
         <source>no_&amp;update</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="optionsdialog.ui" line="116"/>
         <source>&amp;forceupdatepinn</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="optionsdialog.ui" line="126"/>
         <source>&amp;allsd</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="optionsdialog.ui" line="136"/>
         <source>all&amp;usb</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="optionsdialog.ui" line="146"/>
         <source>all&amp;network</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="optionsdialog.ui" line="156"/>
         <source>all&amp;installed</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="optionsdialog.ui" line="166"/>
         <source>&amp;waitsd</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="optionsdialog.ui" line="176"/>
         <source>waitus&amp;b</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="optionsdialog.ui" line="186"/>
         <source>waitnetwor&amp;k</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="optionsdialog.ui" line="196"/>
         <source>waita&amp;ll</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="optionsdialog.ui" line="223"/>
         <source>sil&amp;entreinstallnewer</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="optionsdialog.ui" line="233"/>
         <source>&amp;silentinstall</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="optionsdialog.ui" line="240"/>
         <source>selec&amp;t=</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="optionsdialog.ui" line="264"/>
         <source>no_&amp;default_source</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="optionsdialog.ui" line="274"/>
         <source>disable&amp;usbimages</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="optionsdialog.ui" line="284"/>
         <source>disable&amp;sdimages</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="optionsdialog.ui" line="294"/>
         <source>&amp;showall</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="optionsdialog.ui" line="304"/>
         <source>repo_&amp;list=</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="optionsdialog.ui" line="317"/>
         <source>&amp;repo=</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="optionsdialog.ui" line="337"/>
         <source>alt_&amp;image_source=</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="optionsdialog.ui" line="375"/>
         <source>&amp;remotetimeout=&lt;secs&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="optionsdialog.ui" line="388"/>
         <source>&amp;forcetrigger</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="optionsdialog.ui" line="398"/>
         <source>&amp;gpiotriggerenable</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="optionsdialog.ui" line="408"/>
         <source>&amp;networktimeout=&lt;secs&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="optionsdialog.ui" line="421"/>
         <source>&amp;keyboardtriggerdisable</source>
         <oldsource>&amp;keyboardtriggerenable</oldsource>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="optionsdialog.ui" line="459"/>
         <source>v&amp;ncinstall</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="optionsdialog.ui" line="469"/>
         <source>&amp;vncshare</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="optionsdialog.ui" line="479"/>
         <source>&amp;ssh</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="optionsdialog.ui" line="489"/>
         <source>&amp;rescueshell</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="optionsdialog.ui" line="499"/>
         <source>disablesafe&amp;mode</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="optionsdialog.ui" line="509"/>
         <source>&amp;dsi</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="optionsdialog.ui" line="519"/>
         <source>no_&amp;group</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="optionsdialog.ui" line="529"/>
         <source>no_&amp;cursor</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="optionsdialog.ui" line="539"/>
         <source>&amp;wallpaper_resize</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="optionsdialog.ui" line="549"/>
         <source>dis&amp;play=</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="optionsdialog.ui" line="562"/>
         <source>s&amp;tyle=</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="optionsdialog.ui" line="575"/>
         <source>b&amp;ootmenutimeout=&lt;secs&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="optionsdialog.ui" line="588"/>
         <source>&amp;background=&lt;r,g,b&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="optionsdialog.ui" line="602"/>
         <location filename="optionsdialog.ui" line="634"/>
         <source>none</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="optionsdialog.ui" line="607"/>
         <source>0</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="optionsdialog.ui" line="612"/>
         <source>1</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="optionsdialog.ui" line="617"/>
         <source>2</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="optionsdialog.ui" line="622"/>
         <source>3</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="optionsdialog.ui" line="639"/>
@@ -2112,14 +2125,16 @@ Partition not big enough for new image.</source>
     <message>
         <location filename="optionsdialog.cpp" line="291"/>
         <source>WARNING</source>
-        <translation type="unfinished"></translation>
+        <translation>WARNUNG</translation>
     </message>
     <message>
         <location filename="optionsdialog.cpp" line="292"/>
         <source>Warning: You have chosen the &apos;runinstaller&apos; option.
 This will erase all your OSes on next boot.
 Are you sure?</source>
-        <translation type="unfinished"></translation>
+        <translation>Warnung: Es wurde die Option »runinstaller« gewählt.
+Damit werden beim nächsten Booten alle installierten Betriebssysteme gelöscht.
+Sicher, dass das gewollt ist?</translation>
     </message>
 </context>
 <context>
@@ -2127,17 +2142,17 @@ Are you sure?</source>
     <message>
         <location filename="osgroup.cpp" line="13"/>
         <source>General</source>
-        <translation type="unfinished"></translation>
+        <translation>Allgemein</translation>
     </message>
     <message>
         <location filename="osgroup.cpp" line="14"/>
         <source>Media</source>
-        <translation type="unfinished"></translation>
+        <translation>Medien</translation>
     </message>
     <message>
         <location filename="osgroup.cpp" line="15"/>
         <source>Games</source>
-        <translation type="unfinished"></translation>
+        <translation>Spiele</translation>
     </message>
     <message>
         <location filename="osgroup.cpp" line="16"/>
@@ -2147,12 +2162,12 @@ Are you sure?</source>
     <message>
         <location filename="osgroup.cpp" line="17"/>
         <source>Education</source>
-        <translation type="unfinished"></translation>
+        <translation>Bildung</translation>
     </message>
     <message>
         <location filename="osgroup.cpp" line="18"/>
         <source>Installed</source>
-        <translation type="unfinished"></translation>
+        <translation>Installiert</translation>
     </message>
     <message>
         <location filename="osgroup.cpp" line="19"/>
@@ -2162,23 +2177,23 @@ Are you sure?</source>
     <message>
         <location filename="osgroup.cpp" line="342"/>
         <source>RECOMMENDED</source>
-        <translation type="unfinished">EMPFOHLEN</translation>
+        <translation>EMPFOHLEN</translation>
     </message>
     <message>
         <location filename="osgroup.cpp" line="347"/>
         <source>NEW VERSION</source>
-        <translation type="unfinished"></translation>
+        <translation>NEUE VERSION</translation>
     </message>
     <message>
         <location filename="osgroup.cpp" line="348"/>
         <source>UPDATE</source>
-        <translation type="unfinished"></translation>
+        <translation>UPDATE</translation>
     </message>
     <message>
         <location filename="osgroup.cpp" line="352"/>
         <location filename="osgroup.cpp" line="353"/>
         <source>INSTALLED</source>
-        <translation type="unfinished">INSTALLIERT</translation>
+        <translation>INSTALLIERT</translation>
     </message>
 </context>
 <context>
@@ -2186,62 +2201,62 @@ Are you sure?</source>
     <message>
         <location filename="passwd.ui" line="14"/>
         <source>Reset Password</source>
-        <translation type="unfinished"></translation>
+        <translation>Passwort zurücksetzen</translation>
     </message>
     <message>
         <location filename="passwd.ui" line="45"/>
         <source>Username</source>
-        <translation type="unfinished">Benutzername</translation>
+        <translation>Benutzername</translation>
     </message>
     <message>
         <location filename="passwd.ui" line="71"/>
         <source>Password</source>
-        <translation type="unfinished">Passwort</translation>
+        <translation>Passwort</translation>
     </message>
     <message>
         <location filename="passwd.ui" line="110"/>
         <source>Retype Password</source>
-        <translation type="unfinished"></translation>
+        <translation>Passwort wiederholen</translation>
     </message>
     <message>
         <location filename="passwd.ui" line="123"/>
         <source>Strength</source>
-        <translation type="unfinished"></translation>
+        <translation>Stärke</translation>
     </message>
     <message>
         <location filename="passwd.ui" line="158"/>
         <source>Show Password</source>
-        <translation type="unfinished"></translation>
+        <translation>Passwort anzeigen</translation>
     </message>
     <message>
         <location filename="passwd.ui" line="171"/>
         <source>Use Default</source>
-        <translation type="unfinished"></translation>
+        <translation>Standard verwenden</translation>
     </message>
     <message>
         <location filename="passwd.cpp" line="226"/>
         <source>Very Weak</source>
-        <translation type="unfinished"></translation>
+        <translation>Sehr schwach</translation>
     </message>
     <message>
         <location filename="passwd.cpp" line="227"/>
         <source>Weak</source>
-        <translation type="unfinished"></translation>
+        <translation>Schwach</translation>
     </message>
     <message>
         <location filename="passwd.cpp" line="228"/>
         <source>Good</source>
-        <translation type="unfinished"></translation>
+        <translation>Gut</translation>
     </message>
     <message>
         <location filename="passwd.cpp" line="229"/>
         <source>Strong</source>
-        <translation type="unfinished"></translation>
+        <translation>Stark</translation>
     </message>
     <message>
         <location filename="passwd.cpp" line="230"/>
         <source>Very Strong</source>
-        <translation type="unfinished"></translation>
+        <translation>Sehr stark</translation>
     </message>
 </context>
 <context>
@@ -2249,22 +2264,22 @@ Are you sure?</source>
     <message>
         <location filename="progressslideshowdialog.cpp" line="251"/>
         <source>%1 MB of %2 MB read (%3 MB/sec) Remaining: %4:%5:%6</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 MB von %2 MB gelesen (%3 MB/s)  Verbleibend: %4:%5:%6</translation>
     </message>
     <message>
         <location filename="progressslideshowdialog.cpp" line="253"/>
         <source>%1 MB of %2 MB written (%3 MB/sec) Remaining: %4:%5:%6</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 MB von %2 MB geschrieben (%3 MB/s)  Verbleibend: %4:%5:%6</translation>
     </message>
     <message>
         <location filename="progressslideshowdialog.cpp" line="284"/>
         <source>%1 MB read (%2 MB/sec)</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 MB gelesen (%2 MB/s)</translation>
     </message>
     <message>
         <location filename="progressslideshowdialog.cpp" line="286"/>
         <source>%1 MB written (%2 MB/sec)</source>
-        <translation>%1 MB geschrieben (%2 MB/Sek.)</translation>
+        <translation>%1 MB geschrieben (%2 MB/s)</translation>
     </message>
 </context>
 <context>
@@ -2307,17 +2322,17 @@ Are you sure?</source>
     <message>
         <location filename="languagedialog.cpp" line="34"/>
         <source>Ignore</source>
-        <translation type="unfinished"></translation>
+        <translation>Ignorieren</translation>
     </message>
     <message>
         <location filename="languagedialog.cpp" line="35"/>
         <source>Show Details...</source>
-        <translation type="unfinished"></translation>
+        <translation>Details anzeigen …</translation>
     </message>
     <message>
         <location filename="languagedialog.cpp" line="36"/>
         <source>Hide Details...</source>
-        <translation type="unfinished"></translation>
+        <translation>Details verbergen …</translation>
     </message>
     <message>
         <location filename="languagedialog.cpp" line="27"/>
@@ -2330,13 +2345,13 @@ Are you sure?</source>
     <message>
         <location filename="termsdialog.ui" line="14"/>
         <source>Dialog</source>
-        <translation type="unfinished"></translation>
+        <translation>Dialog</translation>
     </message>
     <message>
         <location filename="termsdialog.ui" line="27"/>
         <source>Please accept these T &amp; Cs to continue.</source>
         <oldsource>Please accept these T&amp;Cs to continue.</oldsource>
-        <translation type="unfinished"></translation>
+        <translation>Bitte diese Geschäftsbedingungen akzeptieren um fortzusetzen.</translation>
     </message>
 </context>
 <context>
@@ -2344,7 +2359,7 @@ Are you sure?</source>
     <message>
         <location filename="WidgetKeyboard.ui" line="14"/>
         <source>Virtual Keyboard</source>
-        <translation type="unfinished"></translation>
+        <translation>Bildschirmtastatur</translation>
     </message>
     <message>
         <location filename="WidgetKeyboard.ui" line="53"/>
@@ -2479,7 +2494,7 @@ Are you sure?</source>
     <message>
         <location filename="WidgetKeyboard.ui" line="404"/>
         <source>Insert</source>
-        <translation type="unfinished"></translation>
+        <translation>Einfg</translation>
     </message>
     <message>
         <location filename="WidgetKeyboard.ui" line="428"/>
@@ -2489,7 +2504,7 @@ Are you sure?</source>
     <message>
         <location filename="WidgetKeyboard.ui" line="431"/>
         <source>Home</source>
-        <translation type="unfinished"></translation>
+        <translation>Pos1</translation>
     </message>
     <message>
         <location filename="WidgetKeyboard.ui" line="452"/>
@@ -2499,7 +2514,7 @@ Are you sure?</source>
     <message>
         <location filename="WidgetKeyboard.ui" line="455"/>
         <source>PgUP</source>
-        <translation type="unfinished"></translation>
+        <translation>Bild Auf</translation>
     </message>
     <message>
         <location filename="WidgetKeyboard.ui" line="476"/>
@@ -2509,7 +2524,7 @@ Are you sure?</source>
     <message>
         <location filename="WidgetKeyboard.ui" line="479"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Entf</translation>
     </message>
     <message>
         <location filename="WidgetKeyboard.ui" line="500"/>
@@ -2519,7 +2534,7 @@ Are you sure?</source>
     <message>
         <location filename="WidgetKeyboard.ui" line="503"/>
         <source>End</source>
-        <translation type="unfinished"></translation>
+        <translation>Ende</translation>
     </message>
     <message>
         <location filename="WidgetKeyboard.ui" line="524"/>
@@ -2529,7 +2544,7 @@ Are you sure?</source>
     <message>
         <location filename="WidgetKeyboard.ui" line="527"/>
         <source>PgDn</source>
-        <translation type="unfinished"></translation>
+        <translation>Bild Ab</translation>
     </message>
     <message>
         <location filename="WidgetKeyboard.ui" line="552"/>
@@ -2689,7 +2704,7 @@ Are you sure?</source>
     <message>
         <location filename="WidgetKeyboard.ui" line="993"/>
         <source>Backspace</source>
-        <translation type="unfinished"></translation>
+        <translation>Rücktaste</translation>
     </message>
     <message>
         <location filename="WidgetKeyboard.ui" line="1021"/>
@@ -2699,7 +2714,7 @@ Are you sure?</source>
     <message>
         <location filename="WidgetKeyboard.ui" line="1024"/>
         <source>    Caps   </source>
-        <translation type="unfinished"></translation>
+        <translation>Feststelltaste</translation>
     </message>
     <message>
         <location filename="WidgetKeyboard.ui" line="1048"/>
@@ -2709,7 +2724,7 @@ Are you sure?</source>
     <message>
         <location filename="WidgetKeyboard.ui" line="1051"/>
         <source>A</source>
-        <translation type="unfinished">A</translation>
+        <translation>A</translation>
     </message>
     <message>
         <location filename="WidgetKeyboard.ui" line="1072"/>
@@ -2729,7 +2744,7 @@ Are you sure?</source>
     <message>
         <location filename="WidgetKeyboard.ui" line="1099"/>
         <source>D</source>
-        <translation type="unfinished">D</translation>
+        <translation>D</translation>
     </message>
     <message>
         <location filename="WidgetKeyboard.ui" line="1120"/>
@@ -2739,7 +2754,7 @@ Are you sure?</source>
     <message>
         <location filename="WidgetKeyboard.ui" line="1123"/>
         <source>F</source>
-        <translation type="unfinished">F</translation>
+        <translation>F</translation>
     </message>
     <message>
         <location filename="WidgetKeyboard.ui" line="1144"/>
@@ -2789,7 +2804,7 @@ Are you sure?</source>
     <message>
         <location filename="WidgetKeyboard.ui" line="1243"/>
         <source>L</source>
-        <translation type="unfinished">L</translation>
+        <translation>L</translation>
     </message>
     <message>
         <location filename="WidgetKeyboard.ui" line="1264"/>
@@ -2819,7 +2834,7 @@ Are you sure?</source>
     <message>
         <location filename="WidgetKeyboard.ui" line="1315"/>
         <source>    Return   </source>
-        <translation type="unfinished"></translation>
+        <translation>   Eingabe   </translation>
     </message>
     <message>
         <location filename="WidgetKeyboard.ui" line="1343"/>
@@ -2830,17 +2845,17 @@ Are you sure?</source>
     <message>
         <location filename="WidgetKeyboard.ui" line="1346"/>
         <source>     Shift     </source>
-        <translation type="unfinished"></translation>
+        <translation>   Umschalt   </translation>
     </message>
     <message>
         <location filename="WidgetKeyboard.ui" line="1370"/>
         <source>0x5a</source>
-        <translation type="unfinished"></translation>
+        <translation>0x59</translation>
     </message>
     <message>
         <location filename="WidgetKeyboard.ui" line="1373"/>
         <source>Z</source>
-        <translation type="unfinished"></translation>
+        <translation>Y</translation>
     </message>
     <message>
         <location filename="WidgetKeyboard.ui" line="1394"/>
@@ -2860,7 +2875,7 @@ Are you sure?</source>
     <message>
         <location filename="WidgetKeyboard.ui" line="1421"/>
         <source>C</source>
-        <translation type="unfinished">C</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="WidgetKeyboard.ui" line="1442"/>
@@ -2880,7 +2895,7 @@ Are you sure?</source>
     <message>
         <location filename="WidgetKeyboard.ui" line="1469"/>
         <source>B</source>
-        <translation type="unfinished">B</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="WidgetKeyboard.ui" line="1490"/>
@@ -2890,7 +2905,7 @@ Are you sure?</source>
     <message>
         <location filename="WidgetKeyboard.ui" line="1493"/>
         <source>N</source>
-        <translation type="unfinished">N</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="WidgetKeyboard.ui" line="1514"/>
@@ -2900,7 +2915,7 @@ Are you sure?</source>
     <message>
         <location filename="WidgetKeyboard.ui" line="1517"/>
         <source>M</source>
-        <translation type="unfinished">M</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="WidgetKeyboard.ui" line="1538"/>
@@ -2935,7 +2950,7 @@ Are you sure?</source>
     <message>
         <location filename="WidgetKeyboard.ui" line="1613"/>
         <source>     Shift      </source>
-        <translation type="unfinished"></translation>
+        <translation>   Umschalt   </translation>
     </message>
     <message>
         <location filename="WidgetKeyboard.ui" line="1644"/>
@@ -2945,7 +2960,7 @@ Are you sure?</source>
     <message>
         <location filename="WidgetKeyboard.ui" line="1647"/>
         <source>    Ctrl     </source>
-        <translation type="unfinished"></translation>
+        <translation>   Strg    </translation>
     </message>
     <message>
         <location filename="WidgetKeyboard.ui" line="1671"/>
@@ -2955,7 +2970,7 @@ Are you sure?</source>
     <message>
         <location filename="WidgetKeyboard.ui" line="1674"/>
         <source>   Alt  </source>
-        <translation type="unfinished"></translation>
+        <translation>   Alt  </translation>
     </message>
     <message>
         <location filename="WidgetKeyboard.ui" line="1698"/>
@@ -2965,7 +2980,7 @@ Are you sure?</source>
     <message>
         <location filename="WidgetKeyboard.ui" line="1717"/>
         <source>Transparency</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Transparenz</translation>
     </message>
     <message>
         <location filename="WidgetKeyboard.ui" line="1745"/>
@@ -2995,7 +3010,7 @@ Are you sure?</source>
     <message>
         <location filename="WidgetKeyboard.ui" line="1796"/>
         <source>W</source>
-        <translation type="unfinished">W</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="WidgetKeyboard.ui" line="1817"/>
@@ -3015,7 +3030,7 @@ Are you sure?</source>
     <message>
         <location filename="WidgetKeyboard.ui" line="1844"/>
         <source>R</source>
-        <translation type="unfinished">R</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="WidgetKeyboard.ui" line="1865"/>
@@ -3025,17 +3040,17 @@ Are you sure?</source>
     <message>
         <location filename="WidgetKeyboard.ui" line="1868"/>
         <source>T</source>
-        <translation type="unfinished">T</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="WidgetKeyboard.ui" line="1889"/>
         <source>0x59</source>
-        <translation type="unfinished"></translation>
+        <translation>0x5a</translation>
     </message>
     <message>
         <location filename="WidgetKeyboard.ui" line="1892"/>
         <source>Y</source>
-        <translation type="unfinished"></translation>
+        <translation>Z</translation>
     </message>
     <message>
         <location filename="WidgetKeyboard.ui" line="1913"/>
@@ -3055,7 +3070,7 @@ Are you sure?</source>
     <message>
         <location filename="WidgetKeyboard.ui" line="1940"/>
         <source>I</source>
-        <translation type="unfinished">I</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="WidgetKeyboard.ui" line="1961"/>
@@ -3075,7 +3090,7 @@ Are you sure?</source>
     <message>
         <location filename="WidgetKeyboard.ui" line="1988"/>
         <source>P</source>
-        <translation type="unfinished">P</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="WidgetKeyboard.ui" line="2009"/>
@@ -3116,7 +3131,8 @@ Are you sure?</source>
         <location filename="WidgetKeyboard.ui" line="2096"/>
         <source>Print
 Screen</source>
-        <translation type="unfinished"></translation>
+        <translation>Druck
+S-Abf</translation>
     </message>
     <message>
         <location filename="WidgetKeyboard.ui" line="2121"/>
@@ -3127,7 +3143,7 @@ Screen</source>
         <location filename="WidgetKeyboard.ui" line="2124"/>
         <source>Scroll
 Lock</source>
-        <translation type="unfinished"></translation>
+        <translation>Rollen</translation>
     </message>
     <message>
         <location filename="WidgetKeyboard.ui" line="2149"/>
@@ -3138,7 +3154,8 @@ Lock</source>
         <location filename="WidgetKeyboard.ui" line="2152"/>
         <source>Pause
 Break</source>
-        <translation type="unfinished"></translation>
+        <translation>Pause
+Untbr</translation>
     </message>
 </context>
 <context>
@@ -3146,17 +3163,17 @@ Break</source>
     <message>
         <location filename="wifisettingsdialog.cpp" line="52"/>
         <source>No wifi interfaces available</source>
-        <translation>Keine WLAN-Schnittstelle verfügbar</translation>
+        <translation>Keine WLAN-Schnittstellen verfügbar</translation>
     </message>
     <message>
         <location filename="wifisettingsdialog.cpp" line="52"/>
         <source>No wifi interfaces</source>
-        <translation type="unfinished"></translation>
+        <translation>Keine WLAN-Schnittstellen</translation>
     </message>
     <message>
         <location filename="wifisettingsdialog.cpp" line="242"/>
         <source>Authenticated but still waiting for DHCP lease</source>
-        <translation>Authentifiziert, warte auf DHCP-Lease</translation>
+        <translation>Authentifiziert, aber es wird noch auf DHCP-Lease gewartet</translation>
     </message>
     <message>
         <location filename="wifisettingsdialog.cpp" line="249"/>
@@ -3166,7 +3183,7 @@ Break</source>
     <message>
         <location filename="wifisettingsdialog.cpp" line="249"/>
         <source>Connecting to the wifi access point failed. Check your password</source>
-        <translation>Verbindungsaufbau zu WLAN-Access-Point fehlgeschlagen. Bitte Passwort überprüfen</translation>
+        <translation>Verbindungsaufbau zu WLAN-Accesspoint fehlgeschlagen. Bitte Passwort überprüfen</translation>
     </message>
     <message>
         <location filename="wifisettingsdialog.cpp" line="284"/>
@@ -3176,12 +3193,12 @@ Break</source>
     <message>
         <location filename="wifisettingsdialog.cpp" line="290"/>
         <source>Releasing old DHCP lease</source>
-        <translation>Gebe altes DHCP-Lease frei</translation>
+        <translation>Altes DHCP-Lease wird freigegeben</translation>
     </message>
     <message>
         <location filename="wifisettingsdialog.cpp" line="305"/>
         <source>Disconnecting</source>
-        <translation>Beende Verbindung</translation>
+        <translation>Verbindung wird beendet</translation>
     </message>
     <message>
         <location filename="wifisettingsdialog.cpp" line="310"/>
@@ -3207,39 +3224,39 @@ Break</source>
         <location filename="wifisettingsdialog.ui" line="64"/>
         <source>Pressing the &amp;WPS button on my wifi router</source>
         <oldsource>Pressing the WPS button on my wifi router</oldsource>
-        <translation type="unfinished">Betätige WPS-Knopf des WLAN-Routers</translation>
+        <translation>&amp;WPS-Taste des WLAN-Routers drücken</translation>
     </message>
     <message>
         <location filename="wifisettingsdialog.ui" line="71"/>
         <source>Password &amp;authentication</source>
         <oldsource>Password authentication</oldsource>
-        <translation type="unfinished">Passwortauthentifizierung</translation>
+        <translation>Passwort&amp;authentifizierung</translation>
     </message>
     <message>
         <location filename="wifisettingsdialog.ui" line="96"/>
         <source>&amp;Username</source>
         <oldsource>Username</oldsource>
-        <translation type="unfinished">Benutzername</translation>
+        <translation>&amp;Benutzername</translation>
     </message>
     <message>
         <location filename="wifisettingsdialog.ui" line="113"/>
         <source>&amp;Password</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Passwort</translation>
     </message>
     <message>
         <location filename="wifisettingsdialog.ui" line="130"/>
         <source>&amp;Show Password</source>
-        <translation type="unfinished"></translation>
+        <translation>Passwort an&amp;zeigen</translation>
     </message>
     <message>
         <location filename="wifisettingsdialog.ui" line="146"/>
         <source>&amp;Virtual Keyboard</source>
-        <translation type="unfinished"></translation>
+        <translation>Bildschirm&amp;tastatur</translation>
     </message>
     <message>
         <location filename="wifisettingsdialog.ui" line="158"/>
         <source>&amp;Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Löschen</translation>
     </message>
 </context>
 <context>
@@ -3247,22 +3264,22 @@ Break</source>
     <message>
         <location filename="backupdialog.ui" line="14"/>
         <source>Set Backup Name</source>
-        <translation type="unfinished"></translation>
+        <translation>Name für Backup festlegen</translation>
     </message>
     <message>
         <location filename="backupdialog.ui" line="61"/>
         <source>ID (date/time)</source>
-        <translation type="unfinished"></translation>
+        <translation>ID (Datum/Uhrzeit)</translation>
     </message>
     <message>
         <location filename="backupdialog.ui" line="77"/>
         <source>OS name</source>
-        <translation type="unfinished"></translation>
+        <translation>Systemname</translation>
     </message>
     <message>
         <location filename="backupdialog.ui" line="122"/>
         <source>Description</source>
-        <translation type="unfinished"></translation>
+        <translation>Beschreibung</translation>
     </message>
 </context>
 <context>
@@ -3270,7 +3287,7 @@ Break</source>
     <message>
         <location filename="chkperms.ui" line="14"/>
         <source>File System Check</source>
-        <translation type="unfinished"></translation>
+        <translation>Dateisystemprüfung</translation>
     </message>
 </context>
 <context>
@@ -3278,17 +3295,17 @@ Break</source>
     <message>
         <location filename="dlginstall.ui" line="14"/>
         <source>Confirm</source>
-        <translation type="unfinished">Bestätigung</translation>
+        <translation>Bestätigen</translation>
     </message>
     <message>
         <location filename="dlginstall.ui" line="71"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;WARNING: Some OSes are already installed!&lt;/p&gt;&lt;p&gt;Continuing to install new OSes will delete your previous installation. Consider using the Replace function if you just want to replace one OS &lt;/p&gt;&lt;p&gt;To continue installing, enter &amp;quot;DELETE&amp;quot; in the box below&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;WARNUNG: Es sind bereits einige Betriebssysteme installiert!&lt;/p&gt;&lt;p&gt;Das Fortsetzen der Installation neuer Betriebssysteme löscht die vorherige Installation. Bitte überlegen, die Funktion Ersetzen zu nutzen, falls nur ein Betriebssystem ersetzt werden soll &lt;/p&gt;&lt;p&gt;Um mit dem Installieren fortzufahren, unten in das Feld &amp;quot;DELETE&amp;quot; eingeben.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location filename="dlginstall.ui" line="93"/>
         <source>Virtual Keyboard</source>
-        <translation type="unfinished"></translation>
+        <translation>Bildschirmtastatur</translation>
     </message>
 </context>
 <context>
@@ -3296,7 +3313,7 @@ Break</source>
     <message>
         <location filename="fscheck.ui" line="14"/>
         <source>File System Check</source>
-        <translation type="unfinished"></translation>
+        <translation>Dateisystemprüfung</translation>
     </message>
 </context>
 <context>
@@ -3304,32 +3321,32 @@ Break</source>
     <message>
         <location filename="piclonethread.cpp" line="87"/>
         <source>Preparing target...</source>
-        <translation type="unfinished"></translation>
+        <translation>Ziel wird vorbereitet …</translation>
     </message>
     <message>
         <location filename="piclonethread.cpp" line="116"/>
         <source>Reading Partitions...</source>
-        <translation type="unfinished"></translation>
+        <translation>Partitionen werden gelesen …</translation>
     </message>
     <message>
         <location filename="piclonethread.cpp" line="161"/>
         <source>Preparing Partitions...</source>
-        <translation type="unfinished"></translation>
+        <translation>Partitionen werden vorbereitet …</translation>
     </message>
     <message>
         <location filename="piclonethread.cpp" line="168"/>
         <source>Creating partition %1 of %2 </source>
-        <translation type="unfinished"></translation>
+        <translation>Partitionen werden erstellt: %1 von %2 </translation>
     </message>
     <message>
         <location filename="piclonethread.cpp" line="289"/>
         <source>Copying partition %d of %d...</source>
-        <translation type="unfinished"></translation>
+        <translation>Partitionen werden kopiert: %d von %d …</translation>
     </message>
     <message>
         <location filename="piclonethread.cpp" line="360"/>
         <source>Copying %1 MB of %2 MB</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 MB von %2 MB werden kopiert</translation>
     </message>
 </context>
 <context>
@@ -3337,22 +3354,22 @@ Break</source>
     <message>
         <location filename="piclonedialog.ui" line="14"/>
         <source>Clone SD Card</source>
-        <translation type="unfinished">Klone die SD-Karte</translation>
+        <translation>SD-Karte klonen</translation>
     </message>
     <message>
         <location filename="piclonedialog.ui" line="42"/>
         <source>Copy From Device:</source>
-        <translation type="unfinished"></translation>
+        <translation>Von Gerät kopieren:</translation>
     </message>
     <message>
         <location filename="piclonedialog.ui" line="75"/>
         <source>Copy To Device:</source>
-        <translation type="unfinished"></translation>
+        <translation>Auf Gerät kopieren:</translation>
     </message>
     <message>
         <location filename="piclonedialog.ui" line="88"/>
         <source>Resize Last Partition</source>
-        <translation type="unfinished"></translation>
+        <translation>Größe der letzten Partition ändern</translation>
     </message>
 </context>
 <context>
@@ -3361,17 +3378,17 @@ Break</source>
         <location filename="renamedialog.ui" line="14"/>
         <location filename="renamedialog.ui" line="61"/>
         <source>Alias</source>
-        <translation type="unfinished"></translation>
+        <translation>Alias</translation>
     </message>
     <message>
         <location filename="renamedialog.ui" line="77"/>
         <source>OS name</source>
-        <translation type="unfinished"></translation>
+        <translation>Systemname</translation>
     </message>
     <message>
         <location filename="renamedialog.ui" line="122"/>
         <source>Description</source>
-        <translation type="unfinished"></translation>
+        <translation>Beschreibung</translation>
     </message>
 </context>
 <context>
@@ -3379,7 +3396,7 @@ Break</source>
     <message>
         <location filename="repair.ui" line="14"/>
         <source>Repair OS</source>
-        <translation type="unfinished"></translation>
+        <translation>Betriebssystem reparieren</translation>
     </message>
 </context>
 <context>
@@ -3387,7 +3404,7 @@ Break</source>
     <message>
         <location filename="replace.ui" line="14"/>
         <source>Replace Installed OSes</source>
-        <translation type="unfinished"></translation>
+        <translation>Installierte Betriebssysteme ersetzen</translation>
     </message>
 </context>
 <context>
@@ -3395,74 +3412,76 @@ Break</source>
     <message>
         <location filename="rerunsetup.cpp" line="27"/>
         <source>No OSes to check</source>
-        <translation type="unfinished"></translation>
+        <translation>Kein Betriebssystem zu überprüfen</translation>
     </message>
     <message>
         <location filename="rerunsetup.cpp" line="31"/>
         <source>Checking for partition_setup.sh scripts...</source>
-        <translation type="unfinished"></translation>
+        <translation>partition_setup.sh-Skripts werden gesucht …</translation>
     </message>
     <message>
         <location filename="rerunsetup.cpp" line="57"/>
         <source>Cannot find setup script for </source>
-        <translation type="unfinished"></translation>
+        <translation>Fehler beim Finden des Setup-Skripts für</translation>
     </message>
     <message>
         <location filename="rerunsetup.cpp" line="58"/>
         <source>Maybe insert source USB stick</source>
-        <translation type="unfinished"></translation>
+        <translation>Eventuell Quell-USB-Stick einstecken</translation>
     </message>
     <message>
         <location filename="rerunsetup.cpp" line="63"/>
         <source>does not support re-running the setup script.</source>
-        <translation type="unfinished"></translation>
+        <translation>unterstützt nicht die erneute Ausführung des Setup-Skripts.</translation>
     </message>
     <message>
         <location filename="rerunsetup.cpp" line="72"/>
         <source> setup script needs to be updated.</source>
-        <translation type="unfinished"></translation>
+        <translation> Setup-Skript benötigt eine Aktualisierung.</translation>
     </message>
     <message>
         <location filename="rerunsetup.cpp" line="89"/>
         <source>Error in checksum for partition_setup.sh</source>
-        <translation type="unfinished"></translation>
+        <translation>Fehler in Prüfsumme für partition_setup.sh</translation>
     </message>
     <message>
         <location filename="rerunsetup.cpp" line="90"/>
         <source>Expected csum= %1 Calculated= %2</source>
-        <translation type="unfinished"></translation>
+        <translation>Erwartete Prüfsumme= %1 Berechnet= %2</translation>
     </message>
     <message>
         <location filename="rerunsetup.cpp" line="155"/>
         <source>%1: Error executing partition setup script</source>
-        <translation type="unfinished">%1: Fehler beim Ausführen des Skripts für Partionserstellung</translation>
+        <translation>%1: Fehler beim Ausführen des Skripts für die Partitionserstellung</translation>
     </message>
     <message>
         <location filename="rerunsetup.cpp" line="160"/>
         <source> partions_setup.sh script error
 </source>
-        <translation type="unfinished"></translation>
+        <translation> partition_setup.sh Skriptfehler
+</translation>
     </message>
     <message>
         <location filename="rerunsetup.cpp" line="162"/>
         <source> partition_setup.sh script OK
 </source>
-        <translation type="unfinished"></translation>
+        <translation> partition_setup.sh Skript OK
+</translation>
     </message>
     <message>
         <location filename="rerunsetup.cpp" line="169"/>
         <source>DONE - some setup script errors detected</source>
-        <translation type="unfinished"></translation>
+        <translation>FERTIG - Einige Setup-Skript-Fehler erkannt</translation>
     </message>
     <message>
         <location filename="rerunsetup.cpp" line="171"/>
         <source>DONE - SUCCESSFUL setup scripts exeuted</source>
-        <translation type="unfinished"></translation>
+        <translation>FERTIG - ERFOLGREICH Setup-Skripts ausgeführt</translation>
     </message>
     <message>
         <location filename="rerunsetup.ui" line="14"/>
         <source>re-run partition_setup</source>
-        <translation type="unfinished"></translation>
+        <translation>partition_setup erneut ausführen</translation>
     </message>
 </context>
 <context>
@@ -3470,12 +3489,12 @@ Break</source>
     <message>
         <location filename="showlog.ui" line="14"/>
         <source>Show Log</source>
-        <translation type="unfinished"></translation>
+        <translation>Protokoll anzeigen</translation>
     </message>
     <message>
         <location filename="showlog.ui" line="55"/>
         <source>&amp;Refresh</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Aktualisieren</translation>
     </message>
 </context>
 </TS>

--- a/recovery/translation_de.ts
+++ b/recovery/translation_de.ts
@@ -5,7 +5,7 @@
     <name>BackupThread</name>
     <message>
         <source>Finish writing (sync)</source>
-        <translation> Schreibvorgang abschließen (sync)</translation>
+        <translation>Schreibvorgang abschließen (sync)</translation>
     </message>
     <message>
         <source>Cannot backup </source>

--- a/recovery/translation_de.ts
+++ b/recovery/translation_de.ts
@@ -943,11 +943,11 @@ Soll fortgesetzt werden?</translation>
     </message>
     <message>
         <source>install</source>
-        <translation>installieren</translation>
+        <translation>Installation</translation>
     </message>
     <message>
         <source>reinstall</source>
-        <translation>neu installieren</translation>
+        <translation>Neuinstallion</translation>
     </message>
     <message>
         <source>replace</source>

--- a/recovery/translation_de.ts
+++ b/recovery/translation_de.ts
@@ -4,52 +4,42 @@
 <context>
     <name>BackupThread</name>
     <message>
-        <location filename="backupthread.cpp" line="66"/>
         <source>Finish writing (sync)</source>
         <translation> Schreibvorgang abschließen (sync)</translation>
     </message>
     <message>
-        <location filename="backupthread.cpp" line="113"/>
         <source>Cannot backup </source>
         <translation>Backup kann nicht erstellt werden</translation>
     </message>
     <message>
-        <location filename="backupthread.cpp" line="113"/>
         <source> :BTRFS file format</source>
         <translation> :BTRFS-Dateiformat</translation>
     </message>
     <message>
-        <location filename="backupthread.cpp" line="235"/>
         <source>%1: Updating partitions.json</source>
         <translation>%1: partitions.json wird aktualisiert</translation>
     </message>
     <message>
-        <location filename="backupthread.cpp" line="189"/>
         <source>%1: Writing image (%2)</source>
         <translation>%1: Image wird geschrieben (%2)</translation>
     </message>
     <message>
-        <location filename="backupthread.cpp" line="196"/>
         <source>%1: Archiving (%2)</source>
         <translation>%1: Wird archiviert (%2)</translation>
     </message>
     <message>
-        <location filename="backupthread.cpp" line="204"/>
         <source>Error writing </source>
         <translation>Fehler beim Schreiben</translation>
     </message>
     <message>
-        <location filename="backupthread.cpp" line="204"/>
         <source>: Disk full?</source>
         <translation>Speicher voll?</translation>
     </message>
     <message>
-        <location filename="backupthread.cpp" line="218"/>
         <source>%1: Checksumming (%2)</source>
         <translation>%1: Prüfsumme wird erstellt (%2)</translation>
     </message>
     <message>
-        <location filename="backupthread.cpp" line="256"/>
         <source>%1: Updating os.json</source>
         <translation>%1: os.json wird aktualisiert</translation>
     </message>
@@ -57,69 +47,55 @@
 <context>
     <name>BootSelectionDialog</name>
     <message>
-        <location filename="bootselectiondialog.cpp" line="72"/>
         <source>Cannot display boot menu</source>
         <translation>Fehler beim Anzeigen des Bootmenüs</translation>
     </message>
     <message>
-        <location filename="bootselectiondialog.cpp" line="72"/>
         <source>Error mounting settings partition</source>
         <translation>Fehler beim Einhängen der Einstellungspartition</translation>
     </message>
     <message>
-        <location filename="bootselectiondialog.cpp" line="328"/>
         <source>HDMI safe mode</source>
         <translation>HDMI-Modus (sicher)</translation>
     </message>
     <message>
-        <location filename="bootselectiondialog.cpp" line="332"/>
         <source>composite PAL mode</source>
         <translation>Composite-PAL-Modus</translation>
     </message>
     <message>
-        <location filename="bootselectiondialog.cpp" line="336"/>
         <source>composite NTSC mode</source>
         <translation>Composite-NTSC-Modus</translation>
     </message>
     <message>
-        <location filename="bootselectiondialog.cpp" line="378"/>
         <source>PINN - Previously selected OS will boot in %1 seconds</source>
         <translation>PINN - Das zuletzt ausgewählte Betriebssystem startet in %1 Sekunden</translation>
     </message>
     <message>
-        <location filename="bootselectiondialog.ui" line="25"/>
-        <location filename="bootselectiondialog.cpp" line="380"/>
         <source>PINN - Select OS to boot</source>
         <translation>PINN - Zu startendes Betriebssystem auswählen</translation>
     </message>
     <message>
-        <location filename="bootselectiondialog.ui" line="38"/>
         <source>Sticky default</source>
         <translation>Als Standard vermerkt</translation>
     </message>
     <message>
-        <location filename="bootselectiondialog.ui" line="45"/>
         <source>&amp;Up</source>
         <oldsource>Up</oldsource>
         <translation>Nach &amp;oben</translation>
     </message>
     <message>
-        <location filename="bootselectiondialog.ui" line="52"/>
         <source>U</source>
         <translation>O</translation>
     </message>
     <message>
-        <location filename="bootselectiondialog.ui" line="59"/>
         <source>&amp;Down</source>
         <translation>Nach &amp;unten</translation>
     </message>
     <message>
-        <location filename="bootselectiondialog.ui" line="66"/>
         <source>D</source>
         <translation>U</translation>
     </message>
     <message>
-        <location filename="bootselectiondialog.ui" line="95"/>
         <source>BOOT</source>
         <translation>STARTEN</translation>
     </message>
@@ -127,28 +103,23 @@
 <context>
     <name>ConfEditDialog</name>
     <message>
-        <location filename="confeditdialog.ui" line="22"/>
         <source>Config editor</source>
         <translation>Konfigurationseditor</translation>
     </message>
     <message>
-        <location filename="confeditdialog.ui" line="36"/>
         <source>&amp;Edit Options</source>
         <oldsource>Edit Options</oldsource>
         <translation>Optionen &amp;bearbeiten</translation>
     </message>
     <message>
-        <location filename="confeditdialog.ui" line="46"/>
         <source>Virtual Keyboard</source>
         <translation>Bildschirmtastatur</translation>
     </message>
     <message>
-        <location filename="confeditdialog.cpp" line="104"/>
         <source>Error</source>
         <translation>Fehler</translation>
     </message>
     <message>
-        <location filename="confeditdialog.cpp" line="105"/>
         <source>Error mounting boot partition</source>
         <translation>Fehler beim Einhängen der Bootpartition</translation>
     </message>
@@ -156,12 +127,10 @@
 <context>
     <name>DateTimeDialog</name>
     <message>
-        <location filename="datetimedialog.ui" line="14"/>
         <source>Set Date &amp; Time</source>
         <translation>Datum und Uhrzeit einstellen</translation>
     </message>
     <message>
-        <location filename="datetimedialog.ui" line="52"/>
         <source>Please set the correct UTC date and time below.</source>
         <oldsource>Please set the correct date and time below.</oldsource>
         <translation>Bitte Datum und Uhrzeit (UTC) unten richtig einstellen.</translation>
@@ -170,43 +139,34 @@
 <context>
     <name>FullFatThread</name>
     <message>
-        <location filename="fullfatthread.cpp" line="39"/>
-        <location filename="fullfatthread.cpp" line="47"/>
         <source>Mounting FAT partition</source>
         <translation>FAT-Partition wird eingehängt</translation>
     </message>
     <message>
-        <location filename="fullfatthread.cpp" line="50"/>
         <source>Error mounting system partition.</source>
         <translation>Fehler beim Einhängen der Systempartition.</translation>
     </message>
     <message>
-        <location filename="fullfatthread.cpp" line="62"/>
         <source>Error opening %1</source>
         <translation>Fehler beim Öffnen von %1</translation>
     </message>
     <message>
-        <location filename="fullfatthread.cpp" line="72"/>
         <source>Finish writing to disk (sync)</source>
         <translation>Schreibvorgang wird abgeschlossen (sync)</translation>
     </message>
     <message>
-        <location filename="fullfatthread.cpp" line="85"/>
         <source>Error unmounting system partition.</source>
         <translation>Fehler beim Aushängen der Systempartition.</translation>
     </message>
     <message>
-        <location filename="fullfatthread.cpp" line="89"/>
         <source>Removing partitions 2,3,4</source>
         <translation>Partitionen 2,3,4 werden entfernt</translation>
     </message>
     <message>
-        <location filename="fullfatthread.cpp" line="103"/>
         <source>Resizing FAT partition</source>
         <translation>Größe der FAT-Partition wird geändert</translation>
     </message>
     <message>
-        <location filename="fullfatthread.cpp" line="127"/>
         <source>Error resizing existing FAT partition</source>
         <translation>Fehler bei Größenanpassung der bestehenden FAT-Partition</translation>
     </message>
@@ -214,41 +174,30 @@
 <context>
     <name>InitDriveThread</name>
     <message>
-        <location filename="initdrivethread.cpp" line="53"/>
-        <location filename="initdrivethread.cpp" line="84"/>
         <source>Mounting FAT partition</source>
         <translation>FAT-Partition wird eingehängt</translation>
     </message>
     <message>
-        <location filename="initdrivethread.cpp" line="77"/>
         <source>Formatting settings partition</source>
         <translation>Einstellungspartition wird formatiert</translation>
     </message>
     <message>
-        <location filename="initdrivethread.cpp" line="80"/>
         <source>Error formatting settings partition</source>
         <translation>Fehler beim Formatieren der Einstellungspartition</translation>
     </message>
     <message>
-        <location filename="initdrivethread.cpp" line="177"/>
-        <location filename="initdrivethread.cpp" line="389"/>
         <source>Error unmounting system partition.</source>
         <translation>Fehler beim Aushängen der Systempartition.</translation>
     </message>
     <message>
-        <location filename="initdrivethread.cpp" line="194"/>
-        <location filename="initdrivethread.cpp" line="393"/>
         <source>Zeroing partition table</source>
         <translation>Partitionstabelle wird gelöscht</translation>
     </message>
     <message>
-        <location filename="initdrivethread.cpp" line="197"/>
-        <location filename="initdrivethread.cpp" line="396"/>
         <source>Error zero&apos;ing MBR/GPT. SD card may be broken or advertising wrong capacity.</source>
         <translation>Fehler beim Löschen der Partitionstabelle (MBR/GPT). Die SD-Karte ist möglicherweise beschädigt oder meldet eine falsche Kapazität.</translation>
     </message>
     <message>
-        <location filename="initdrivethread.cpp" line="188"/>
         <source>Would you like PINN to create one for you?
 WARNING: This will erase all data on your SD card.</source>
         <oldsource>Would you like PINN to create one for you?
@@ -257,138 +206,111 @@ WARNING: This will erase all data on your SD card</oldsource>
 Achtung: Dies löscht alle Daten auf dieser SD-Karte.</translation>
     </message>
     <message>
-        <location filename="initdrivethread.cpp" line="189"/>
         <source>Error: No MBR present on SD Card</source>
         <translation>Fehler: Keine Partitionstabelle (MBR) auf der SD-Karte vorhanden</translation>
     </message>
     <message>
-        <location filename="initdrivethread.cpp" line="202"/>
         <source>Writing new MBR</source>
         <translation>Neue Partitionstabelle (MBR) wird geschrieben</translation>
     </message>
     <message>
-        <location filename="initdrivethread.cpp" line="210"/>
         <source>Error creating MBR</source>
         <translation>Fehler beim Erstellen der Partitionstabelle (MBR)</translation>
     </message>
     <message>
-        <location filename="initdrivethread.cpp" line="218"/>
         <source>SD card has now been formatted ready for PINN installation. Please re-copy the PINN files onto the card and reboot</source>
         <oldsource>SD card has now been formatted ready for NOOBS installation. Please re-copy the NOOBS files onto the card and reboot</oldsource>
         <translation>Die SD-Karte wurde für die Installation von PINN formatiert. Bitte die PINN-Dateien erneut auf die SD-Karte kopieren und neu starten</translation>
     </message>
     <message>
-        <location filename="initdrivethread.cpp" line="223"/>
         <source>SD card has not been formatted correctly. Please reformat using the SD Association Formatting Tool and try again.</source>
         <translation>Die SD-Karte wurde nicht korrekt formatiert. Bitte die Karte mit Hilfe des »SD Association Formatting Tool« neu formatieren und es erneut versuchen.</translation>
     </message>
     <message>
-        <location filename="initdrivethread.cpp" line="229"/>
         <source>Removing partitions 2,3,4</source>
         <translation>Partitionen 2,3,4 werden entfernt</translation>
     </message>
     <message>
-        <location filename="initdrivethread.cpp" line="243"/>
         <source>Resizing FAT partition</source>
         <translation>Größe der FAT-Partition wird angepasst</translation>
     </message>
     <message>
-        <location filename="initdrivethread.cpp" line="267"/>
         <source>Error resizing existing FAT partition</source>
         <translation>Fehler bei Größenanpassung der bestehenden FAT-Partition</translation>
     </message>
     <message>
-        <location filename="initdrivethread.cpp" line="273"/>
         <source>Creating extended partition</source>
         <translation>Erweiterte Partition wird erstellt</translation>
     </message>
     <message>
-        <location filename="initdrivethread.cpp" line="307"/>
         <source>Error creating extended partition</source>
         <translation>Fehler beim Erstellen der erweiterten Partition</translation>
     </message>
     <message>
-        <location filename="initdrivethread.cpp" line="381"/>
         <source>Saving boot files to memory</source>
         <translation>Boot-Dateien werden auf Karte gespeichert</translation>
     </message>
     <message>
-        <location filename="initdrivethread.cpp" line="384"/>
         <source>Error saving boot files to memory. SD card may be damaged.</source>
         <translation>Fehler beim Speichern der Boot-Dateien. Die SD-Karte ist möglicherweise beschädigt.</translation>
     </message>
     <message>
-        <location filename="initdrivethread.cpp" line="400"/>
         <source>Creating partitions</source>
         <translation>Partitionen werden erstellt</translation>
     </message>
     <message>
-        <location filename="initdrivethread.cpp" line="404"/>
         <source>Error partitioning</source>
         <translation>Fehler beim Partitionieren</translation>
     </message>
     <message>
-        <location filename="initdrivethread.cpp" line="408"/>
         <source>Formatting boot partition (fat)</source>
         <translation>Boot-Partition wird formatiert (FAT)</translation>
     </message>
     <message>
-        <location filename="initdrivethread.cpp" line="411"/>
         <source>Error formatting boot partition (fat)</source>
         <translation>Fehler beim Partitionieren (FAT)</translation>
     </message>
     <message>
-        <location filename="initdrivethread.cpp" line="415"/>
         <source>Copying boot files to storage</source>
         <translation>Boot-Dateien werden auf den Speicher kopiert</translation>
     </message>
     <message>
-        <location filename="initdrivethread.cpp" line="510"/>
         <source>Setting disk volume ID</source>
         <translation>Disk-Volume-ID wird gesetzt</translation>
     </message>
     <message>
-        <location filename="initdrivethread.cpp" line="87"/>
         <source>Error mounting system partition.</source>
         <translation>Fehler beim Einhängen der Systempartition.</translation>
     </message>
     <message>
-        <location filename="initdrivethread.cpp" line="92"/>
         <source>Editing cmdline.txt</source>
         <translation>cmdline.txt wird bearbeitet</translation>
     </message>
     <message>
-        <location filename="initdrivethread.cpp" line="102"/>
         <source>Error opening %1</source>
         <translation>Fehler beim Öffnen von %1</translation>
     </message>
     <message>
-        <location filename="initdrivethread.cpp" line="115"/>
         <source>Writing RiscOS blob</source>
         <translation>RiscOS blob wird geschrieben</translation>
     </message>
     <message>
-        <location filename="initdrivethread.cpp" line="118"/>
         <source>Error writing RiscOS blob</source>
         <translation>Fehler beim Schreiben des RiscOS blob</translation>
     </message>
     <message>
-        <location filename="initdrivethread.cpp" line="125"/>
         <source>Unmounting boot partition</source>
         <translation>Boot-Partition wird ausgehängt</translation>
     </message>
     <message>
-        <location filename="initdrivethread.cpp" line="128"/>
         <source>Finish writing to disk (sync)</source>
         <translation>Schreibvorgang wird abgeschlossen (sync)</translation>
     </message>
     <message>
-        <location filename="initdrivethread.cpp" line="138"/>
         <source>Mounting boot partition again</source>
         <translation>Die Boot-Partition wird erneut eingehängt</translation>
     </message>
     <message>
-        <location filename="initdrivethread.cpp" line="149"/>
         <source>SD card broken (writes do not persist)</source>
         <translation>Die SD-Karte ist defekt (geschriebene Daten bleiben nicht erhalten)</translation>
     </message>
@@ -396,12 +318,10 @@ Achtung: Dies löscht alle Daten auf dieser SD-Karte.</translation>
 <context>
     <name>LanguageDialog</name>
     <message>
-        <location filename="languagedialog.ui" line="135"/>
         <source>Language (l): </source>
         <translation>Sprache (l): </translation>
     </message>
     <message>
-        <location filename="languagedialog.ui" line="156"/>
         <source>Keyboard</source>
         <translation>Tastaturlayout</translation>
     </message>
@@ -409,454 +329,344 @@ Achtung: Dies löscht alle Daten auf dieser SD-Karte.</translation>
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="mainwindow.ui" line="74"/>
-        <location filename="mainwindow.ui" line="185"/>
         <source>Destination drive:</source>
         <translation>Ziellaufwerk:</translation>
     </message>
     <message>
-        <location filename="mainwindow.ui" line="103"/>
-        <location filename="mainwindow.ui" line="208"/>
         <source>Needed:</source>
         <translation>Benötigt:</translation>
     </message>
     <message>
-        <location filename="mainwindow.ui" line="129"/>
         <source>Model</source>
         <oldsource>model</oldsource>
         <translation>Modell</translation>
     </message>
     <message>
-        <location filename="mainwindow.ui" line="110"/>
-        <location filename="mainwindow.ui" line="215"/>
         <source>Available:</source>
         <translation>Verfügbar:</translation>
     </message>
     <message>
-        <location filename="mainwindow.ui" line="139"/>
         <source>Memory</source>
         <translation>Speicher</translation>
     </message>
     <message>
-        <location filename="mainwindow.ui" line="173"/>
         <source>Download space</source>
         <translation>Download-Speicherplatz</translation>
     </message>
     <message>
-        <location filename="mainwindow.ui" line="264"/>
-        <location filename="mainwindow.ui" line="304"/>
         <source>toolBar</source>
         <translation>Symbolleiste</translation>
     </message>
     <message>
-        <location filename="mainwindow.ui" line="400"/>
         <source>Install (i)</source>
         <translation>Installieren (i)</translation>
     </message>
     <message>
-        <location filename="mainwindow.ui" line="403"/>
         <source>Installs the selected operating system image onto this SD card.</source>
         <translation>Installiert das ausgewählte Betriebssystem-Image auf die SD-Karte.</translation>
     </message>
     <message>
-        <location filename="mainwindow.ui" line="406"/>
         <source>I</source>
         <translation>I</translation>
     </message>
     <message>
-        <location filename="mainwindow.ui" line="415"/>
         <source>Exit (Esc)</source>
         <translation>Beenden (Esc)</translation>
     </message>
     <message>
-        <location filename="mainwindow.ui" line="418"/>
         <source>Exits and boots the installed operating system.</source>
         <translation>Beendet PINN und startet das ausgewählte Betriebssystem.</translation>
     </message>
     <message>
-        <location filename="mainwindow.ui" line="433"/>
         <source>More (m)</source>
         <translation>Mehr (m)</translation>
     </message>
     <message>
-        <location filename="mainwindow.ui" line="436"/>
         <source>More menus</source>
         <translation>Mehr Menüs</translation>
     </message>
     <message>
-        <location filename="mainwindow.ui" line="439"/>
         <source>M</source>
         <translation>M</translation>
     </message>
     <message>
-        <location filename="mainwindow.ui" line="532"/>
         <source>Download (d)</source>
         <translation>Download (d)</translation>
     </message>
     <message>
-        <location filename="mainwindow.ui" line="535"/>
         <source>Downloads the selected operating system image to USB for local installation</source>
         <translation>Lädt die ausgewählten Betriebssystem-Images auf den USB-Stick für eine spätere lokale Installation</translation>
     </message>
     <message>
-        <location filename="mainwindow.ui" line="538"/>
         <source>D</source>
         <translation>D</translation>
     </message>
     <message>
-        <location filename="mainwindow.ui" line="571"/>
         <source>Reinstall (r)</source>
         <oldsource>Refresh (r)</oldsource>
         <translation>Neu installieren (r)</translation>
     </message>
     <message>
-        <location filename="mainwindow.ui" line="574"/>
-        <location filename="mainwindow.ui" line="733"/>
         <source>R</source>
         <translation>R</translation>
     </message>
     <message>
-        <location filename="mainwindow.ui" line="589"/>
         <source>Replace (c)</source>
         <oldsource>Replace (l)</oldsource>
         <translation>Ersetzen (e)</translation>
     </message>
     <message>
-        <location filename="mainwindow.ui" line="592"/>
-        <location filename="mainwindow.ui" line="658"/>
-        <location filename="mainwindow.ui" line="688"/>
         <source>C</source>
         <oldsource>L</oldsource>
         <translation>e</translation>
     </message>
     <message>
-        <location filename="mainwindow.ui" line="643"/>
         <source>Wipe (w)</source>
         <translation>Löschen (w)</translation>
     </message>
     <message>
-        <location filename="mainwindow.ui" line="670"/>
         <source>Information about the installed OS</source>
         <translation>Informationen über das installierte Betriebssystem</translation>
     </message>
     <message>
-        <location filename="mainwindow.ui" line="682"/>
         <source>Clear (c)</source>
         <translation>Abwählen (c)</translation>
     </message>
     <message>
-        <location filename="mainwindow.ui" line="685"/>
         <source>Clear selection</source>
         <translation>Auswahl abwählen</translation>
     </message>
     <message>
-        <location filename="mainwindow.ui" line="697"/>
         <source>Time (t)</source>
         <translation>Zeit (t)</translation>
     </message>
     <message>
-        <location filename="mainwindow.ui" line="700"/>
-        <source>Set Data &amp; Time</source>
+        <source>Set Date &amp; Time</source>
+        <oldsource>Set Data &amp; Time</oldsource>
         <translation>Datum und Uhrzeit einstellen</translation>
     </message>
     <message>
-        <location filename="mainwindow.ui" line="703"/>
         <source>T</source>
         <translation>T</translation>
     </message>
     <message>
-        <location filename="mainwindow.ui" line="712"/>
         <source>Alias (a)</source>
         <translation>Alias (a)</translation>
     </message>
     <message>
-        <location filename="mainwindow.ui" line="715"/>
         <source>Rename an OS with an alias</source>
         <translation>Ein Betriebssystem mit einem Alias umbenennen</translation>
     </message>
     <message>
-        <location filename="mainwindow.ui" line="718"/>
         <source>A</source>
         <translation>A</translation>
     </message>
     <message>
-        <location filename="mainwindow.ui" line="727"/>
         <source>Reload Repos (r)</source>
         <translation>Repos neu laden (r)</translation>
     </message>
     <message>
-        <location filename="mainwindow.ui" line="730"/>
         <source>Scans Repositories and reloads lists of new OSes</source>
         <translation>Scannt Repositorys und lädt Listen neuer Betriebssysteme nach</translation>
     </message>
     <message>
-        <location filename="mainwindow.ui" line="499"/>
         <source>Wifi (w)</source>
         <translation>WLAN (w)</translation>
     </message>
     <message>
-        <location filename="mainwindow.ui" line="62"/>
         <source>Install space</source>
         <translation>Installationsspeicherplatz</translation>
     </message>
     <message>
-        <location filename="mainwindow.ui" line="517"/>
         <source>Password (p)</source>
         <translation>Passwort (p)</translation>
     </message>
     <message>
-        <location filename="mainwindow.ui" line="520"/>
         <source>Change password</source>
         <translation>Passwort ändern</translation>
     </message>
     <message>
-        <location filename="mainwindow.ui" line="523"/>
         <source>P</source>
         <translation>P</translation>
     </message>
     <message>
-        <location filename="mainwindow.ui" line="553"/>
         <source>Backup (b)</source>
         <translation>Backup erstellen (b)</translation>
     </message>
     <message>
-        <location filename="mainwindow.ui" line="556"/>
         <source>B</source>
         <translation>B</translation>
     </message>
     <message>
-        <location filename="mainwindow.ui" line="607"/>
         <source>fsck (f)</source>
         <oldsource>fschk (f)</oldsource>
         <translation>fsck (f)</translation>
     </message>
     <message>
-        <location filename="mainwindow.ui" line="610"/>
-        <location filename="mainwindow.ui" line="628"/>
         <source>F</source>
         <translation>F</translation>
     </message>
     <message>
-        <location filename="mainwindow.ui" line="625"/>
         <source>Fix (f)</source>
         <translation>Reparieren (f)</translation>
     </message>
     <message>
-        <location filename="mainwindow.ui" line="655"/>
         <source>Clone (c)</source>
         <translation>Klonen (c)</translation>
     </message>
     <message>
-        <location filename="mainwindow.ui" line="347"/>
         <source>Advanced</source>
         <translation>Erweitert</translation>
     </message>
     <message>
-        <location filename="mainwindow.ui" line="451"/>
         <source>Edit config (e)</source>
         <translation>Konfiguration bearbeiten (e)</translation>
     </message>
     <message>
-        <location filename="mainwindow.ui" line="454"/>
         <source>Opens the config.txt and cmdline.txt for the installed OS in a text editor.</source>
         <translation>Öffnet config.txt und cmdline.txt des installierten Betriebssystems im Texteditor.</translation>
     </message>
     <message>
-        <location filename="mainwindow.ui" line="466"/>
         <source>Online help (h)</source>
         <translation>Online-Hilfe (h)</translation>
     </message>
     <message>
-        <location filename="mainwindow.ui" line="469"/>
         <source>Opens a web browser displaying the Raspberry Pi Forum.</source>
         <translation>Öffnet das Raspberry-Pi-Forum in einem Browser.</translation>
     </message>
     <message>
-        <location filename="mainwindow.ui" line="481"/>
-        <location filename="mainwindow.ui" line="667"/>
         <source>Info (n)</source>
         <translation>Info (n)</translation>
     </message>
     <message>
-        <location filename="mainwindow.ui" line="484"/>
         <source>Information about the selected OS</source>
         <translation>Informationen über das ausgewählte Betriebssystem</translation>
     </message>
     <message>
-        <location filename="mainwindow.ui" line="487"/>
-        <location filename="mainwindow.ui" line="673"/>
         <source>N</source>
         <translation>N</translation>
     </message>
     <message>
-        <location filename="mainwindow.ui" line="502"/>
         <source>Select a wifi network to connect to</source>
         <translation>Auswahl eines WLANs, zu dem eine Verbindung hergestellt werden soll</translation>
     </message>
     <message>
-        <location filename="mainwindow.ui" line="505"/>
-        <location filename="mainwindow.ui" line="646"/>
         <source>W</source>
         <translation>W</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="4019"/>
-        <location filename="mainwindow.cpp" line="4065"/>
         <source>RECOMMENDED</source>
         <translation>EMPFOHLEN</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1069"/>
-        <location filename="mainwindow.cpp" line="1078"/>
-        <location filename="mainwindow.cpp" line="1189"/>
-        <location filename="mainwindow.cpp" line="1298"/>
-        <location filename="mainwindow.cpp" line="1308"/>
-        <location filename="mainwindow.cpp" line="1938"/>
-        <location filename="mainwindow.cpp" line="4764"/>
-        <location filename="mainwindow.cpp" line="4839"/>
-        <location filename="mainwindow.cpp" line="4883"/>
         <source>Confirm</source>
         <translation>Bestätigen</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="365"/>
         <source>Setting up SD card</source>
         <translation>SD-Karte wird eingerichtet</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="412"/>
         <source>Error mounting settings partition</source>
         <translation>Fehler beim Einhängen der Einstellungspartition</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="413"/>
         <source>Persistent settings partition seems corrupt. Reformat?</source>
         <translation>Die Einstellungspartition scheint fehlerhaft zu sein. Neu formatieren?</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="420"/>
         <source>Reformat failed</source>
         <translation>Neuformatierung fehlgeschlagen</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="420"/>
         <source>SD card might be damaged</source>
         <translation>Die SD-Karte ist möglicherweise beschädigt</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="677"/>
         <source>Please wait while PINN initialises</source>
         <translation>Bitte warten während PINN startet</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1131"/>
-        <location filename="mainwindow.cpp" line="4784"/>
         <source> is not available.
 Please provide it locally or connect to the internet.</source>
         <translation> ist nicht verfügbar.
 Dies bitte lokal zur Verfügung stellen oder mit dem Internet verbinden.</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1431"/>
         <source>OS(es) Downloaded Successfully.</source>
         <translation>Betriebssystem(e) erfolgreich heruntergeladen.</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1500"/>
-        <location filename="mainwindow.cpp" line="1534"/>
-        <location filename="mainwindow.cpp" line="1548"/>
-        <location filename="mainwindow.cpp" line="2247"/>
-        <location filename="mainwindow.cpp" line="2390"/>
-        <location filename="mainwindow.cpp" line="4342"/>
         <source>Error</source>
         <translation>Fehler</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1605"/>
         <source>PINN v%1 - Built: %2 (%3) %4</source>
         <translation>PINN Version %1 - Erstellt: %2 (%3) %4</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1721"/>
         <source>Display Mode Changed</source>
         <translation>Darstellungsmodus geändert</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1640"/>
         <source>HDMI preferred mode</source>
         <translation>HDMI-bevorzugter Modus</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="387"/>
         <source>Waiting for SD card (settings partition)</source>
         <translation>Auf SD-Karte wird gewartet (Einstellungspartition)</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="400"/>
         <source>Mounting settings partition</source>
         <translation>Einstellungspartition wird eingehängt</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="658"/>
         <source>Main Menu</source>
         <translation>Hauptmenü</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="659"/>
         <source>Archival</source>
         <translation>Archivierung</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="660"/>
         <source>Maintenance</source>
         <translation>Wartung</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1060"/>
         <source>ERROR</source>
         <translation>FEHLER</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1061"/>
         <source>Error: Some OSes are not available:
 </source>
         <translation>Fehler: Einige Betriebssysteme sind nicht verfügbar:
 </translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1180"/>
         <source>SD card</source>
         <translation>SD-Karte</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1079"/>
-        <location filename="mainwindow.cpp" line="1309"/>
         <source>Warning: incompatible Operating System(s) detected. The following OSes aren&apos;t supported on this revision of Raspberry Pi and may fail to boot or function correctly:</source>
         <translation>Achtung: Inkompatible(s) Betriebssystem(e) gefunden. Die nachfolgenden Betriebssysteme werden von dieser Revision des Raspberry Pi nicht unterstützt und werden möglicherweise nicht korrekt funktionieren oder starten:</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="322"/>
         <source>RUNINSTALLER - Initialise Drive</source>
         <translation>RUNINSTALLER - Laufwerk initialisieren</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="323"/>
         <source>There are existing OSes installed.
 Are you sure you want to initialise the drive?</source>
         <translation>Es sind bereits Betriebssysteme installiert.
 Sicher, dass das Laufwerk initialisiert werden soll?</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1070"/>
-        <location filename="mainwindow.cpp" line="4765"/>
         <source>Warning: Partial USB support. The following OSes can only be executed from USB when it is /dev/sda and may fail to boot or function correctly if that is not the case:
 </source>
         <oldsource>Warning: Partial USB support. The following OSes can only be installed to USB when it is /dev/sda and may fail to boot or function correctly if that is not the case:</oldsource>
         <translation>Warnung: Partielle USB-Unterstützung. Folgenden Betriebssysteme können nur von USB ausgeführt werden, wenn es sich um /dev/sda handelt, und booten oder funktionieren möglicherweise nicht korrekt, wenn dies nicht der Fall ist:</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1070"/>
-        <location filename="mainwindow.cpp" line="4765"/>
         <source>
 
 Do you want to continue?</source>
@@ -865,39 +675,32 @@ Do you want to continue?</source>
 Soll fortgesetzt werden?</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1146"/>
         <source>ReInstall OSes</source>
         <translation>Betriebssystem(e) neu installieren</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1147"/>
         <source>Warning: No OSes selected or available
 </source>
         <translation>Warnung: Keine Betriebssysteme ausgewählt oder verfügbar
 </translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1185"/>
         <source>Warning: this will %1 the selected Operating System(s) on %2. The partitions of the selected OSes will first be erased.</source>
         <translation>Warnung: Damit werden die gewählten Betriebssysteme auf %2 %1. Die Partitionen der gewählten Betriebssysteme werden vorher gelöscht.</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1299"/>
         <source>Warning: this will download the selected Operating System(s).</source>
         <translation>Warnung: Dies lädt die ausgewählten Betriebssysteme herunter.</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1386"/>
         <source>The download process will begin shortly.</source>
         <translation>Der Download beginnt gleich.</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1434"/>
         <source>OS(es) downloaded</source>
         <translation>Betriebssystem(e) heruntergeladen</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1448"/>
         <source>OS(es) Backed up with errors.
 See debug log for details.</source>
         <oldsource>OS(es) Backed up with errors.
@@ -906,147 +709,112 @@ See debug log for details</oldsource>
 Siehe Fehlerprotokoll für weitere Einzelheiten.</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1450"/>
         <source>OS(es) Backed up Successfully.</source>
         <translation>Betriebssystem(e) erfolgreich gesichert.</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1452"/>
-        <location filename="mainwindow.cpp" line="4987"/>
         <source>Backup OSes</source>
         <translation>Betriebssysteme sichern</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1461"/>
         <source>OS(es) Installed Successfully</source>
         <oldsource>OS Installed Successfully</oldsource>
         <translation>Betriebssystem(e) erfolgreich installiert</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1463"/>
         <source>Installation complete</source>
         <translation>Installation beendet</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1576"/>
         <source>Abort</source>
         <translation>Abbruch</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1577"/>
         <source>Discard</source>
         <translation>Verwerfen</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1578"/>
         <source>Retry</source>
         <translation>Wiederholen</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1579"/>
         <source>Keep</source>
         <translation>Behalten</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1603"/>
         <source>Reboot in %1 secs</source>
         <translation>Neustart in %1 Sekunde(n)</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1644"/>
         <source>HDMI safe mode</source>
         <translation>Sicherer HDMI-Modus</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1648"/>
         <source>composite PAL mode</source>
         <translation>Composite-PAL-Modus</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1652"/>
         <source>composite NTSC mode</source>
         <translation>Composite-NTSC-Modus</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1722"/>
         <source>Display mode changed to %1
 Would you like to make this setting permanent?</source>
         <translation>Darstellungsmodus geändert zu %1
 Soll diese Einstellung dauerhaft gespeichert werden?</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1913"/>
         <source>Wiping SD card</source>
         <translation>SD-Karte wird überschrieben</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1939"/>
         <source>Warning: this will restore your PINN drive to its initial state. All existing data on the drive except PINN will be overwritten, including any OSes that are already installed.</source>
         <oldsource>Warning: this will restore your SD card to its initial state. All existing data on the SD card except PINN will be overwritten, including any OSes that are already installed.</oldsource>
         <translation>Warnung: Damit wird das PINN-Laufwerk in seinen Initialzustand zurückgesetzt. Außer PINN werden alle Daten auf dem Laufwerk, einschließlich aller installierter Betriebssysteme, überschrieben.</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1944"/>
         <source>Drive Wiped!</source>
         <translation>Laufwerk überschrieben!</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="2228"/>
-        <location filename="mainwindow.cpp" line="2366"/>
         <source>Error downloading distribution list from Internet:
 </source>
         <translation>Fehler beim Herunterladen der Distributionsliste aus dem Internet:
 </translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="2230"/>
-        <location filename="mainwindow.cpp" line="2368"/>
-        <location filename="mainwindow.cpp" line="2887"/>
-        <location filename="mainwindow.cpp" line="2898"/>
-        <location filename="mainwindow.cpp" line="4441"/>
-        <location filename="mainwindow.cpp" line="4463"/>
         <source>Download error</source>
         <translation>Download-Fehler</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="2247"/>
         <source>Error parsing repolist.json downloaded from server</source>
         <translation>Fehler beim Verarbeiten der repolist.json vom Server</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="2873"/>
         <source>Error downloading meta file: </source>
         <translation>Fehler beim Download einer Metadatei:</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="3242"/>
-        <location filename="mainwindow.cpp" line="4755"/>
-        <location filename="mainwindow.cpp" line="4793"/>
         <source>Replace OSes</source>
         <translation>Betriebssystem(e) ersetzen</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="3289"/>
         <source>Resume partial downloads?</source>
         <translation>Partielle Downloads fortsetzen?</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="3290"/>
         <source>Normally select NO, unless your last download was not successful, in which case select YES</source>
         <translation>Normalerweise NEIN wählen, es sei denn, der letzte Download war nicht erfolgreich; in diesem Fall JA wählen</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="3514"/>
         <source>This backup may require </source>
         <translation>Dieses Backup braucht vielleicht</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="3516"/>
         <source> MB of backup space, but only </source>
         <translation>MB Backup-Speicher, aber nur</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="3518"/>
         <source> MB is available. This is only an estimate. If you continue, the backup may not complete successfully.
 
 Do you want to continue?</source>
@@ -1055,171 +823,149 @@ Do you want to continue?</source>
 Soll fortgesetzt werden?</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="3519"/>
         <source>WARNING: Backup Space</source>
         <translation>WARNUNG: Backup-Speicher</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="3526"/>
         <source>Backup Info</source>
         <translation>Backup-Info</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="3526"/>
         <source>Always test your backups before relying on them</source>
         <translation>Backups immer testen, bevor sich darauf verlassen wird</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="3576"/>
         <source>Network access is required to use PINN without local images. Please select your wifi network in the next screen.</source>
         <translation>Netzwerkzugriff ist erforderlich, um PINN ohne lokalen Images zu verwenden. Bitte das WLAN-Netzwerk auf der nächsten Seite auswählen.</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="3584"/>
         <source>Wired network access is required to use PINN without local images. Please insert a network cable into the network port.</source>
         <translation>Kabelgebundenes Netzwerk ist erforderlich, um PINN ohne lokale Images zu verwenden. Bitte ein Netzwerkkabel mit dem Netzwerkanschluss verbinden.</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="3916"/>
         <source>Are you sure you want to reformat the drive &apos;%1&apos; for use with PINN? All existing data on the drive will be deleted!</source>
         <translation>Soll das Laufwerk »%1« wirklich für die Verwendung mit PINN neu formatiert werden? Alle vorhanden Daten auf dem Laufwerk werden gelöscht!</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="4294"/>
         <source>This will erase all content on the device &apos;%s&apos;. Are you sure?</source>
         <translation>Dies löscht alle Daten auf dem Laufwerk »%s«. Ganz sicher?</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="4296"/>
         <source>Clone SD Card</source>
         <translation>SD-Karte klonen</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="4298"/>
         <source>Yes</source>
         <translation>Ja</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="4299"/>
         <source>No</source>
         <translation>Nein</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="4328"/>
         <source>Clone Completed</source>
         <translation>Klonen abgeschlossen</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="4329"/>
         <source>Clone Completed Successfully</source>
         <translation>Klonen erfolgreich abgeschlossen</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="4441"/>
         <source>Error downloading update file</source>
-        <translation>Fehler beim Herunterladen der Update-Datei</translation>
+        <translation>Fehler beim Herunterladen der Updatedatei</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="4448"/>
-        <location filename="mainwindow.cpp" line="4549"/>
         <source>PINN Update Check</source>
-        <translation>PINN Update-Prüfung</translation>
+        <translation>PINN-Updateprüfung</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="4448"/>
         <source>Error contacting update server</source>
         <translation>Fehler beim Kontaktieren des Update-Servers</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="4549"/>
+        <source>PINN will now update and reboot in a few secs...</source>
+        <translation>PINN wird jetzt aktualisiert und in wenigen Sekunden rebooten …</translation>
+    </message>
+    <message>
+        <source>PINN update failed</source>
+        <translation>PINN-Update fehlgeschlagen</translation>
+    </message>
+    <message>
         <source>No updates available</source>
         <translation>Kein Update verfügbar</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="4558"/>
+        <source>Executing preupdate</source>
+        <translation>Pre-Update wird ausgeführt</translation>
+    </message>
+    <message>
+        <source>Extracting update</source>
+        <translation>Update wird extrahiert</translation>
+    </message>
+    <message>
         <source>PINN UPDATE</source>
-        <translation>PINN UPDATE</translation>
+        <translation>PINN-UPDATE</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="4559"/>
         <source>A new version of PINN is available</source>
-        <translation>Eine neue Version von PINN ist verfügbar</translation>
+        <translation>Eine neue PINN-Version ist verfügbar</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="4560"/>
         <source>Do you want to download this version?</source>
         <translation>Soll diese Version heruntergeladen werden?</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="4592"/>
         <source>Downloading Update</source>
         <translation>Update wird heruntergeladen</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="4592"/>
-        <source>Press ESC to cancel</source>
-        <translation>Zum Abbrechen die ESC-Taste drücken</translation>
-    </message>
-    <message>
-        <location filename="mainwindow.cpp" line="4756"/>
         <source>Error: No OSes selected
 (Do not choose RISC OS or PINN)</source>
         <translation>Fehler: Kein Betriebssystem ausgewählt
 (Bitte nicht RISC oder PINN auswählen)</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="4794"/>
         <source>Warning: No OSes selected
 </source>
         <translation>Warnung: Kein Betriebssystem ausgewählt</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="4840"/>
         <source>Warning: this will backup the selected Operating System(s).</source>
         <translation>Warnung: Damit werden die gewählten Betriebssysteme gesichert (Backup).</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="4884"/>
         <source>Warning: Unsupported Operating System(s) detected. PINN currently cannot backup the following OSes correctly:</source>
         <translation>Warnung: Nicht unterstützte(s) Betriebssystem(e) erkannt. PINN kann gegenwärtig folgende Betriebssysteme nicht korrekt sichern (Backup):</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="2390"/>
         <source>Error parsing list.json downloaded from server</source>
         <translation>Fehler beim Verarbeiten der vom Server geladenen list.json</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1164"/>
         <source>install</source>
         <translation>installieren</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1167"/>
         <source>reinstall</source>
         <translation>neu installieren</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1170"/>
         <source>replace</source>
         <translation>ersetzen</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1180"/>
         <source>USB drive</source>
         <translation>USB-Laufwerk</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1181"/>
         <source>Warning: this will %1 the selected Operating System(s) to %2. All existing data on the %3 will be deleted.</source>
         <translation>Warnung: Damit werden die ausgewählten Betriebssysteme auf %2 %1. Alle vorhandenen Daten auf %3 werden gelöscht.</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1276"/>
         <source>The %1 process will begin shortly.</source>
         <translation>Der Prozess %1 beginnt gleich.</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1429"/>
         <source>OS(es) Downloaded with errors.
 See debug log for details.</source>
         <oldsource>OS(es) Downloaded with errors.
@@ -1228,7 +974,6 @@ See debug log for details</oldsource>
 Siehe Fehlerprotokoll für weitere Einzelheiten.</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1459"/>
         <source>OS(es) Installed with errors.
 See debug log for details.</source>
         <oldsource>OS(es) Installed with errors.
@@ -1237,7 +982,6 @@ See debug log for details</oldsource>
 Siehe Fehlerprotokoll für weitere Einzelheiten.</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1945"/>
         <source>Warning: Any installed OSes have been wiped and the drive has been restored to its original size.
 Install and download will no longer work until this drive is re-booted.
 Booting this drive again will re-instate PINN&apos;s partition structure.</source>
@@ -1246,90 +990,73 @@ Installieren und Herunterladen funktionieren nicht mehr, bis dieses Laufwerk neu
 Ein erneutes Booten dieses Laufwerks stellt die Partitionsstruktur von PINN wieder her.</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="2659"/>
-        <location filename="mainwindow.cpp" line="2662"/>
         <source>Needed</source>
         <translation>Benötigt</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="2660"/>
-        <location filename="mainwindow.cpp" line="2663"/>
         <source>Available</source>
         <translation>Verfügbar</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="2887"/>
         <source>Error downloading meta file</source>
         <translation>Fehler beim Herunterladen der Metadatei</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="2898"/>
-        <location filename="mainwindow.cpp" line="4463"/>
         <source>Error writing downloaded file to SD card. SD card or file system may be damaged.</source>
         <translation>Fehler beim Schreiben der heruntergeladenen Datei auf die SD-Karte. Die SD-Karte oder das Dateisystem könnte fehlerhaft sein.</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="3010"/>
         <source>filesize error checking </source>
         <translation>Überprüfung der Dateigröße</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="3243"/>
         <source> has an incompatible number of partitions with </source>
         <translation>hat eine inkompatible Anzahl Partitionen mit </translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="3915"/>
         <source>Reformat drive?</source>
         <translation>Laufwerk neu formatieren?</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1958"/>
-        <location filename="mainwindow.cpp" line="3575"/>
-        <location filename="mainwindow.cpp" line="3583"/>
         <source>No network access</source>
         <translation>Kein Netzwerkzugriff</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1959"/>
         <source>Wired network access is required for this feature. Please insert a network cable into the network port.</source>
         <translation>Für diese Funktion ist eine kabelgebundene Netzwerkverbindung erforderlich. Bitte ein Netzwerkkabel einstecken.</translation>
+    </message>
+    <message>
+        <source>Executing postupdate</source>
+        <translation>Post-Update wird ausgeführt</translation>
     </message>
 </context>
 <context>
     <name>MultiImageDownloadThread</name>
     <message>
-        <location filename="multiimagedownloadthread.cpp" line="58"/>
         <source>Finish writing (sync)</source>
         <translation>Schreibvorgang wird abgeschlossen (sync)</translation>
     </message>
     <message>
-        <location filename="multiimagedownloadthread.cpp" line="94"/>
         <source>File &apos;%1&apos; does not need downloading</source>
         <translation>Datei »%1« muss nicht heruntergeladen werden</translation>
     </message>
     <message>
-        <location filename="multiimagedownloadthread.cpp" line="105"/>
         <source>Downloading %1:%2</source>
         <translation>%1 herunterladen: %2</translation>
     </message>
     <message>
-        <location filename="multiimagedownloadthread.cpp" line="143"/>
         <source>Checking %1:%2</source>
         <translation>%1 überprüfen: %2</translation>
     </message>
     <message>
-        <location filename="multiimagedownloadthread.cpp" line="153"/>
         <source>Error in checksum</source>
         <translation>Fehler in Prüfsumme</translation>
     </message>
     <message>
-        <location filename="multiimagedownloadthread.cpp" line="161"/>
         <source>Error downloading or extracting tarball</source>
         <translation>Fehler beim Herunterladen oder Extrahieren des TAR-Archivs</translation>
     </message>
     <message>
-        <location filename="multiimagedownloadthread.cpp" line="199"/>
         <source>Finished downloading %1</source>
         <translation>%1 wurde vollständig heruntergeladen</translation>
     </message>
@@ -1337,256 +1064,196 @@ Ein erneutes Booten dieses Laufwerks stellt die Partitionsstruktur von PINN wied
 <context>
     <name>MultiImageWriteThread</name>
     <message>
-        <location filename="multiimagewritethread.cpp" line="97"/>
         <source>partitions.json invalid</source>
         <translation>partitions.json ungültig</translation>
     </message>
     <message>
-        <location filename="multiimagewritethread.cpp" line="121"/>
         <source>RISCOS cannot be installed. Size of recovery partition too large.</source>
         <translation>RISCOS kann nicht installiert werden. Die Recovery-Partition ist zu groß.</translation>
     </message>
     <message>
-        <location filename="multiimagewritethread.cpp" line="155"/>
         <source>Operating system cannot require a system partition (1,5)</source>
         <translation>Betriebssystem kann keine Systempartition erfordern (1,5)</translation>
     </message>
     <message>
-        <location filename="multiimagewritethread.cpp" line="160"/>
         <source>Operating system cannot claim both primary partitions 2 and 4</source>
         <translation>Das Betriebssystem kann nicht beide primären Partitionen 2 und 4 beanspruchen</translation>
     </message>
     <message>
-        <location filename="multiimagewritethread.cpp" line="189"/>
         <source>Not enough disk space. Need %1 MB, got %2 MB</source>
         <translation>Unzureichender Speicherplatz. %1 MB benötigt, nur %2 MB verfügbar</translation>
     </message>
     <message>
-        <location filename="multiimagewritethread.cpp" line="447"/>
         <source>Finish writing (sync)</source>
         <translation>Schreibvorgang wird abgeschlossen (sync)</translation>
     </message>
     <message>
-        <location filename="multiimagewritethread.cpp" line="738"/>
         <source>File &apos;%1&apos; does not exist</source>
         <translation>Datei »%1« existiert nicht</translation>
     </message>
     <message>
-        <location filename="multiimagewritethread.cpp" line="778"/>
-        <location filename="multiimagewritethread.cpp" line="785"/>
         <source>%1: Writing OS image</source>
         <oldsource>Writing image</oldsource>
         <translation>%1: Betriebssystem-Image wird geschrieben</translation>
     </message>
     <message>
-        <location filename="multiimagewritethread.cpp" line="801"/>
         <source>%1: Mounting file system</source>
         <oldsource>Mounting file system</oldsource>
         <translation>%1: Dateisystem wird eingehängt</translation>
     </message>
     <message>
-        <location filename="multiimagewritethread.cpp" line="804"/>
-        <location filename="multiimagewritethread.cpp" line="841"/>
-        <location filename="multiimagewritethread.cpp" line="997"/>
-        <location filename="multiimagewritethread.cpp" line="1107"/>
         <source>%1: Error mounting file system</source>
         <oldsource>Error mounting file system</oldsource>
         <translation>%1: Fehler beim Einhängen des Dateisystems</translation>
     </message>
     <message>
-        <location filename="multiimagewritethread.cpp" line="792"/>
         <source>%1: Creating filesystem (%2)</source>
         <translation>%1: Dateisystem wird erstellt (%2)</translation>
     </message>
     <message>
-        <location filename="multiimagewritethread.cpp" line="110"/>
         <source>RISCOS cannot be installed. RISCOS offset value mismatch.</source>
         <translation>RISCOS kann nicht installiert werden. Wert des RISCOS-Offsets stimmt nicht überein.</translation>
     </message>
     <message>
-        <location filename="multiimagewritethread.cpp" line="116"/>
         <source>RISCOS cannot be installed. RISCOS offset value missing.</source>
         <translation>RISCOS kann nicht installiert werden. Wert für RISCOS-Offset fehlt.</translation>
     </message>
     <message>
-        <location filename="multiimagewritethread.cpp" line="150"/>
         <source>More than one operating system requires partition number %1</source>
         <translation>Mehr als ein Betriebssystem benötigt Partition Nummer %1</translation>
     </message>
     <message>
-        <location filename="multiimagewritethread.cpp" line="218"/>
         <source>Cannot boot partitions &gt; 62. Reduce the number of OSes</source>
         <translation>Partitionen &gt; 62 können nicht gebootet werden. Bitte die Anzahl der Betriebssysteme reduzieren</translation>
     </message>
     <message>
-        <location filename="multiimagewritethread.cpp" line="240"/>
         <source>Cannot boot partitions &gt; #62. Reduce the number of OSes</source>
         <translation>Partitionen &gt; #62 können nicht gebootet werden. Bitte die Anzahl der Betriebssysteme reduzieren</translation>
     </message>
     <message>
-        <location filename="multiimagewritethread.cpp" line="269"/>
         <source>Fixed partition offset too low</source>
         <translation>Fester Partitionsoffset zu gering</translation>
     </message>
     <message>
-        <location filename="multiimagewritethread.cpp" line="329"/>
         <source>Writing partition table</source>
         <translation>Partitionstabelle wird geschrieben</translation>
     </message>
     <message>
-        <location filename="multiimagewritethread.cpp" line="344"/>
         <source>Writing boot partition table</source>
         <translation>Boot-Partitionstabelle (MBR) wird geschrieben</translation>
     </message>
     <message>
-        <location filename="multiimagewritethread.cpp" line="334"/>
-        <location filename="multiimagewritethread.cpp" line="350"/>
         <source>Zero&apos;ing start of each partition</source>
         <translation>Beginn jeder Partition wird mit Null überschrieben</translation>
     </message>
     <message>
-        <location filename="multiimagewritethread.cpp" line="395"/>
         <source>.
 Partition not big enough for new image.</source>
         <translation>.
 Partition ist für das neue Image nicht groß genug.</translation>
     </message>
     <message>
-        <location filename="multiimagewritethread.cpp" line="395"/>
         <source>Cannot Reinstall/Replace </source>
         <translation>Fehler bei Neuinstallation bzw. beim Ersetzen</translation>
     </message>
     <message>
-        <location filename="multiimagewritethread.cpp" line="441"/>
         <source>Operation cancelled by user</source>
         <translation>Vorgang durch Anwender abgebrochen</translation>
     </message>
     <message>
-        <location filename="multiimagewritethread.cpp" line="468"/>
         <source>Error reading existing partition table</source>
         <translation>Fehler beim Einlesen der bestehenden Partitionstabelle</translation>
     </message>
     <message>
-        <location filename="multiimagewritethread.cpp" line="553"/>
         <source>Error creating partition table</source>
         <translation>Fehler beim Erstellen der Partitionstabelle</translation>
     </message>
     <message>
-        <location filename="multiimagewritethread.cpp" line="766"/>
         <source>OS: &apos;%1&apos; needs a partition label of &apos;%2&apos; which is not available</source>
         <translation>Betriebssystem: »%1« benötigt ein Partitionslabel mit »%2«, das nicht verfügbar ist</translation>
     </message>
     <message>
-        <location filename="multiimagewritethread.cpp" line="809"/>
         <source>%1: Downloading and extracting filesystem</source>
         <translation>%1: Dateisystem wird heruntergeladen und entpackt</translation>
     </message>
     <message>
-        <location filename="multiimagewritethread.cpp" line="811"/>
         <source>%1: Extracting filesystem</source>
         <oldsource>%1 Extracting filesystem</oldsource>
         <translation>%1: Dateisystem wird entpackt</translation>
     </message>
     <message>
-        <location filename="multiimagewritethread.cpp" line="820"/>
         <source>Syncing Filesystem</source>
         <translation>Dateisystem wird synchronisiert</translation>
     </message>
     <message>
-        <location filename="multiimagewritethread.cpp" line="838"/>
-        <location filename="multiimagewritethread.cpp" line="993"/>
         <source>%1: Mounting FAT partition</source>
         <oldsource>Mouning FAT partition</oldsource>
         <translation>%1: FAT-Partition eingehängt</translation>
     </message>
     <message>
-        <location filename="multiimagewritethread.cpp" line="845"/>
         <source>%1: Creating os_config.json</source>
         <oldsource>Creating os_config.json</oldsource>
         <translation>%1: os_config.json wird erstellt</translation>
     </message>
     <message>
-        <location filename="multiimagewritethread.cpp" line="878"/>
         <source>%1: Saving display mode to config.txt</source>
         <oldsource>Saving display mode to config.txt</oldsource>
         <translation>%1: Speicher Darstellungsmodus in config.txt</translation>
     </message>
     <message>
-        <location filename="multiimagewritethread.cpp" line="899"/>
         <source>Error in checksum for partition_setup.sh</source>
         <translation>Fehler in Prüfsumme für partition_setup.sh</translation>
     </message>
     <message>
-        <location filename="multiimagewritethread.cpp" line="906"/>
         <source>%1: Running partition setup script</source>
         <oldsource>Running partition setup script</oldsource>
         <translation>%1: Skript für Partitionserstellung wird ausgeführt</translation>
     </message>
     <message>
-        <location filename="multiimagewritethread.cpp" line="963"/>
         <source>%1: Error executing partition setup script</source>
         <oldsource>Error executing partition setup script</oldsource>
         <translation>%1: Fehler beim Ausführen des Skripts für Partitionserstellung</translation>
     </message>
     <message>
-        <location filename="multiimagewritethread.cpp" line="980"/>
         <source>%1: Configuring flavour</source>
         <translation>%1: Variante wird konfiguriert</translation>
     </message>
     <message>
-        <location filename="multiimagewritethread.cpp" line="970"/>
-        <location filename="multiimagewritethread.cpp" line="1001"/>
         <source>%1: Unmounting FAT partition</source>
         <oldsource>%1: Patching BCD file</oldsource>
         <translation>%1: FAT-Partition wird ausgehängt</translation>
     </message>
     <message>
-        <location filename="multiimagewritethread.cpp" line="973"/>
-        <location filename="multiimagewritethread.cpp" line="1004"/>
         <source>%1: Error unmounting</source>
         <oldsource>Error unmounting</oldsource>
         <translation>%1: Fehler beim Aushängen</translation>
     </message>
     <message>
-        <location filename="multiimagewritethread.cpp" line="1414"/>
         <source>Error creating file system</source>
         <translation>Fehler beim Erstellen des Dateisystems</translation>
     </message>
     <message>
-        <location filename="multiimagewritethread.cpp" line="1487"/>
-        <location filename="multiimagewritethread.cpp" line="1604"/>
-        <location filename="multiimagewritethread.cpp" line="1697"/>
         <source>Unknown compression format file extension. Expecting .lzo, .gz, .xz, .bz2 or .zip.</source>
         <oldsource>Unknown compression format file extension. Expecting .lzo, .gz, .xz, .bz2 or .zip</oldsource>
         <translation>Unbekanntes Kompressionsformat in Dateierweiterung. .Es wird lzo, .gz, .xz, .bz2 oder .zip erwartet.</translation>
     </message>
     <message>
-        <location filename="multiimagewritethread.cpp" line="1527"/>
-        <location filename="multiimagewritethread.cpp" line="1635"/>
-        <location filename="multiimagewritethread.cpp" line="1728"/>
         <source>An incorrect file checksum has been detected in %1</source>
         <translation>In %1 wurde eine falsche Dateiprüfsumme entdeckt</translation>
     </message>
     <message>
-        <location filename="multiimagewritethread.cpp" line="1528"/>
-        <location filename="multiimagewritethread.cpp" line="1639"/>
-        <location filename="multiimagewritethread.cpp" line="1732"/>
         <source>Checksum error</source>
         <translation>Prüfsummenfehler</translation>
     </message>
     <message>
-        <location filename="multiimagewritethread.cpp" line="1538"/>
         <source>Checksum OK</source>
         <translation>Prüfsumme OK</translation>
     </message>
     <message>
-        <location filename="multiimagewritethread.cpp" line="1541"/>
         <source>Finished downloading</source>
         <translation>Download beendet</translation>
     </message>
     <message>
-        <location filename="multiimagewritethread.cpp" line="1649"/>
-        <location filename="multiimagewritethread.cpp" line="1742"/>
         <source>Error downloading or writing OS to SD card</source>
         <translation>Fehler beim Herunterladen oder Schreiben des Betriebssystems auf die SD-Karte</translation>
     </message>
@@ -1594,541 +1261,427 @@ Partition ist für das neue Image nicht groß genug.</translation>
 <context>
     <name>OptionsDialog</name>
     <message>
-        <location filename="optionsdialog.ui" line="14"/>
         <source>PINN Options</source>
         <translation>PINN Optionen</translation>
     </message>
     <message>
-        <location filename="optionsdialog.ui" line="35"/>
         <source>Installation</source>
         <translation>Installation</translation>
     </message>
     <message>
-        <location filename="optionsdialog.ui" line="43"/>
         <source>PREVENTS any noobsconfig customisations from being applied to an OS on installation</source>
         <translation>VERHINDERT, dass jegliche noobsconfig-Anpassungen bei der Installation auf ein Betriebssystem angewendet werden</translation>
     </message>
     <message>
-        <location filename="optionsdialog.ui" line="46"/>
         <source>noobs&amp;config</source>
         <oldsource>noobsconfig</oldsource>
         <translation></translation>
     </message>
     <message>
-        <location filename="optionsdialog.ui" line="53"/>
         <source>Reserve some space on PINN&apos;s partition (MB)</source>
         <translation>Ein Speicherbereich auf der PINN-Partition reservieren (MB)</translation>
     </message>
     <message>
-        <location filename="optionsdialog.ui" line="56"/>
         <source>re&amp;serve=</source>
         <oldsource>reserve=</oldsource>
         <translation>Re&amp;serve=</translation>
     </message>
     <message>
-        <location filename="optionsdialog.ui" line="66"/>
-        <location filename="optionsdialog.ui" line="79"/>
         <source>Specifies a path or URL where the noobsconfig customisation files can be found (rather than being in /os/&amp;lt;distro&amp;gt;/)</source>
         <translation>Gibt eine Pfad oder eine URL an, wo die noobsconfig-Anpassungsdateien zu finden sind (und nicht in /os/&amp;lt;distro&amp;gt;/)</translation>
     </message>
     <message>
-        <location filename="optionsdialog.ui" line="86"/>
         <source>Amount of space to reserve (MB) on PINN&apos;s partition</source>
         <translation>Zu reservierender Speicherplatz (MB) auf der PINN-Partition</translation>
     </message>
     <message>
-        <location filename="optionsdialog.ui" line="93"/>
         <source>Selecting this will erase all of your OSes</source>
         <translation>Bei Auswahl dieser Option werden alle vorhandenen Betriebssysteme gelöscht</translation>
     </message>
     <message>
-        <location filename="optionsdialog.ui" line="103"/>
         <source>Prevents PINN from checking for self updates</source>
         <translation>Verhindert, dass PINN nach Selbstaktualisierungen sucht</translation>
     </message>
     <message>
-        <location filename="optionsdialog.ui" line="113"/>
         <source>Force PINN to self-update whenever a new version is detected</source>
         <translation>PINN zur Selbstaktualisierung zwingen, sobald eine neue Version ermittelt wird</translation>
     </message>
     <message>
-        <location filename="optionsdialog.ui" line="123"/>
         <source>Selects all OSes where the most recent one is on the SD card</source>
         <oldsource>DO not update the firmware of old OSes on installation</oldsource>
         <translation>Wählt alle Betriebssysteme aus, deren aktuellstes sich auf der SD-Karte befindet</translation>
     </message>
     <message>
-        <location filename="optionsdialog.ui" line="133"/>
         <source>Selects all OSes where the most recent one is on a local USB drive</source>
         <oldsource> Selects all OSes where the most recent one is on a local USB drive</oldsource>
         <translation>Wählt alle Betriebssysteme aus, deren aktuellstes sich auf einem lokalen USB-Laufwerk befindet</translation>
     </message>
     <message>
-        <location filename="optionsdialog.ui" line="143"/>
         <source>Selects all OSes where the most recent one is on remote repositories.</source>
         <translation>Wählt alle Betriebssysteme aus, deren aktuellstes sich auf entfernten Repositorys befindet.</translation>
     </message>
     <message>
-        <location filename="optionsdialog.ui" line="153"/>
         <source>Ensures all installed OSes are selected again.</source>
         <translation>Stellt sicher, dass alle installierten Betriebssysteme wieder ausgewählt werden.</translation>
     </message>
     <message>
-        <location filename="optionsdialog.ui" line="163"/>
         <source>Waits for all OSes on the SD card to be listed</source>
         <translation>Wartet darauf, dass alle Betriebssysteme auf der SD-Karte aufgelistet werden</translation>
     </message>
     <message>
-        <location filename="optionsdialog.ui" line="173"/>
         <source>Waits for all OSes on local USBs to be listed</source>
         <oldsource> Waits for all OSes on local USBs to be listed</oldsource>
         <translation>Wartet darauf, dass alle Betriebssysteme auf lokalen USB-Laufwerken aufgelistet werden</translation>
     </message>
     <message>
-        <location filename="optionsdialog.ui" line="183"/>
         <source>Waits for all OS lists to be downloaded from the internet before checking the list of OSes</source>
         <translation>Wartet, bis alle Betriebssystemlisten aus dem Internet heruntergeladen sind, bevor die Liste der Betriebssysteme überprüft wird</translation>
     </message>
     <message>
-        <location filename="optionsdialog.ui" line="193"/>
         <source>Waits for OSes from all sources to be listed</source>
         <oldsource> Waits for OSes from all sources to be listed</oldsource>
         <translation>Wartet darauf, dass die Betriebssysteme aus allen Quellen aufgelistet werden</translation>
     </message>
     <message>
-        <location filename="optionsdialog.ui" line="203"/>
         <source>The list of OSes that will be selected at startup</source>
         <translation>Die Liste der Betriebssysteme, die beim Starten ausgewählt werden</translation>
     </message>
     <message>
-        <location filename="optionsdialog.ui" line="210"/>
         <source>Reserve an ADDITIONAL amount of space</source>
         <translation>Eine ZUSÄTZLICHE Menge des Speicherplatzes reservieren</translation>
     </message>
     <message>
-        <location filename="optionsdialog.ui" line="213"/>
         <source>+</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="optionsdialog.ui" line="220"/>
         <source>Automatically reinstalls any selected OSes if newer versions exist</source>
         <translation>Es werden alle ausgewählten Betriebssysteme automatisch neu installiert, wenn neuere Versionen vorhanden sind</translation>
     </message>
     <message>
-        <location filename="optionsdialog.ui" line="230"/>
         <source>Allows a single or multiple OSes to be installed automatically, useful during headless installs. </source>
         <translation>Erlaubt die automatische Installation eines oder mehrerer Betriebssysteme, nützlich bei Headless-Installationen.</translation>
     </message>
     <message>
-        <location filename="optionsdialog.ui" line="253"/>
         <source>Source</source>
         <translation>Quelle</translation>
     </message>
     <message>
-        <location filename="optionsdialog.ui" line="261"/>
         <source>Prevents the default RaspberryPi Foundation repository from being used.</source>
         <translation>Verhindert, dass das Standard-Repository der RaspberryPi Foundation verwendet wird.</translation>
     </message>
     <message>
-        <location filename="optionsdialog.ui" line="271"/>
         <source>Prevents OSes stored on local USB memory devices from being used.</source>
         <translation>Verhindert, dass Betriebssysteme verwendet werden, die auf lokalen USB-Speichergeräten gespeichert sind.</translation>
     </message>
     <message>
-        <location filename="optionsdialog.ui" line="281"/>
         <source>Prevent OSes stored on the SD card from being used.</source>
         <translation>Verhindert, dass Betriebssysteme verwendet werden, die auf SD-Karten gespeichert sind.</translation>
     </message>
     <message>
-        <location filename="optionsdialog.ui" line="291"/>
         <source>Shows all available installable OSes, whether they are suitable for the current model of Pi or not. Useful for preparing SD cards to be used in other RPis.</source>
         <translation>Zeigt alle verfügbaren installierbaren Betriebssysteme an, egal ob sie für das aktuelle Pi-Modell geeignet sind oder nicht. Nützlich für die Vorbereitung von SD-Karten, die in anderen RPis verwendet werden sollen.</translation>
     </message>
     <message>
-        <location filename="optionsdialog.ui" line="301"/>
-        <location filename="optionsdialog.ui" line="327"/>
         <source>Provides the URL of a repo_list.json file that contains a list of URLs to other os-list_v3.json files. This allows easy remote management of Internet repositories.</source>
         <translation>Gibt die URL einer repo_list.json-Datei an, die eine Liste von URLs zu anderen os-list_v3.json-Dateien enthält. Dies ermöglicht eine einfache Fernverwaltung von Internet-Repositorys.</translation>
     </message>
     <message>
-        <location filename="optionsdialog.ui" line="314"/>
-        <location filename="optionsdialog.ui" line="347"/>
         <source>Similar to alt_image_source but it matches the NOOBS method of specifying a list of additional respositories as a space separated quoted string.</source>
         <oldsource> Similar to alt_image_source but it matches the NOOBS method of specifying a list of additional respositories as a space separated quoted string.</oldsource>
         <translation>Ähnlich zu alt_image_source, entspricht jedoch der NOOBS-Methode, bei der eine Liste zusätzlicher Speicherorte in Form einer durch Leerzeichen getrennten und in Anführungszeichen gesetzten Zeichenkette angegeben wird.</translation>
     </message>
     <message>
-        <location filename="optionsdialog.ui" line="334"/>
-        <location filename="optionsdialog.ui" line="354"/>
         <source>: Provides the URL of an additional os_list_v3.json file indicating the location of other OSes that can be downloaded from the Internet. Multiple instances of this option can be used.</source>
         <translation>: Gibt die URL einer zusätzlichen os_list_v3.json-Datei an, die den Ort anderer Betriebssysteme angibt, die aus dem Internet heruntergeladen werden können. Es können mehrere Instanzen dieser Option verwendet werden.</translation>
     </message>
     <message>
-        <location filename="optionsdialog.ui" line="364"/>
         <source>Booting</source>
         <translation>Booten</translation>
     </message>
     <message>
-        <location filename="optionsdialog.ui" line="372"/>
-        <location filename="optionsdialog.ui" line="428"/>
         <source>When used in conjunction with forcetrigger it sets a maximum timeout period in seconds for the recovery menu to be displayed before continuing to the boot selection dialog and potentially selecting a default OS to boot.</source>
         <oldsource> When used in conjunction with forcetrigger it sets a maximum timeout period in seconds for the recovery menu to be displayed before continuing to the boot selection dialog and potentially selecting a default OS to boot.</oldsource>
         <translation>In Verbindung mit forcetrigger wird eine maximale Zeitspanne in Sekunden festgelegt, für dier das Wiederherstellungsmenü angezeigt wird, bevor das Fenster für das Fenster der Boot-Auswahl erscheint und gegebenenfalls ein Standardbetriebssystem zum Booten ausgewählt wird.</translation>
     </message>
     <message>
-        <location filename="optionsdialog.ui" line="385"/>
         <source>Forces the PINN interface to be entered on startup (as if the shift key had been pressed). This is very useful when using a VNC connection.</source>
         <translation>Erzwingt die Anzeige der PINN-Oberfläche beim Starten (als ob die Umschalttaste gedrückt worden wäre). Dies ist sehr nützlich bei der Verwendung einer VNC-Verbindung.</translation>
     </message>
     <message>
-        <location filename="optionsdialog.ui" line="395"/>
         <source>Forces Recovery Mode to be entered on boot if GPIO pin 3 on header P1 is connected to GND (pin 25).</source>
         <translation>Erzwingt den Start in den Wiederherstellungsmodus, wenn GPIO-Pin 3 an der Stiftleiste P1 mit GND (Pin 25) verbunden ist.</translation>
     </message>
     <message>
-        <location filename="optionsdialog.ui" line="405"/>
-        <location filename="optionsdialog.ui" line="435"/>
         <source>This setting allows the network timeout to be specified in seconds, especially for networks that take longer to establish.</source>
         <oldsource> This setting allows the network timeout to be specified in seconds, especially for networks that take longer to establish.</oldsource>
         <translation>Mit dieser Einstellung kann die Netzwerkzeitüberschreitung in Sekunden angegeben werden, insbesondere für Netzwerke, die beim Aufbau länger brauchen.</translation>
     </message>
     <message>
-        <location filename="optionsdialog.ui" line="418"/>
         <source>Prevents a SHIFT keypress from entering Recovery Mode on boot (maybe you have a problematic keyboard which is erroneously triggering every time you boot)</source>
         <oldsource>Prevents a SHIFT keypress from entering Recovery Mode on boot (maybe you have a problematic keyboard which is erroneously triggering every time you boot)</oldsource>
         <translation>Verhindert, dass ein Tastendruck auf die UMSCHALTTASTE beim Booten den Wiederherstellungsmodus aktiviert (vielleicht wird eine fehlerhafte Tastatur verwendet, die bei jedem Booten irrtümlich ausgelöst wird)</translation>
     </message>
     <message>
-        <location filename="optionsdialog.ui" line="445"/>
         <source>Interface</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="optionsdialog.ui" line="456"/>
         <source>Uses a VNC network connection to control PINN instead of any locally attached keyboard, mouse and display. When this is used, any local display will remain blank.</source>
         <translation>Verwendet eine VNC-Netzwerkverbindung zur Steuerung von PINN anstelle einer lokal angeschlossenen Tastatur, Maus und Bildschirm. Wird dies verwendet, bleibt ein lokaler Bildschirm ohne Anzeige.</translation>
     </message>
     <message>
-        <location filename="optionsdialog.ui" line="466"/>
         <source>Uses a VNC network connection to control PINN. However, unlike vncinstall, any locally attached keyboard and mouse will still be active and the display will be duplicated to the local screen and the VNC connection.</source>
         <oldsource>Uses a VNC network connection to control PINN. However, unlike vncinstall, any locally attached keyboard and mouse will still be active and the display will be duplicated to the local screen and the VNC connection.</oldsource>
         <translation>Verwendet eine VNC-Netzwerkverbindung zur Steuerung von PINN. Im Gegensatz zu vncinstall sind jedoch alle lokal angeschlossenen Tastaturen und Mäuse weiterhin aktiv und die Anzeige wird auf den lokalen Bildschirm und die VNC-Verbindung dupliziert.</translation>
     </message>
     <message>
-        <location filename="optionsdialog.ui" line="476"/>
         <source>Enables an SSH connection to the rescueshell in PINN. It cannot be used to control PINN, but having a shell is very useful to perform remote maintenance on any of the SD card partitions.</source>
         <oldsource>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Enables an SSH connection to the rescueshell in PINN. It cannot be used to control PINN, but having a shell is very useful to perform remote maintenance on any of the SD card partitions.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</oldsource>
         <translation>Ermöglicht eine SSH-Verbindung zur Rescueshell in PINN. Sie kann nicht zur Steuerung von PINN verwendet werden, aber eine Shell ist sehr nützlich, um Fernwartung auf einer der SD-Kartenpartitionen durchzuführen.</translation>
     </message>
     <message>
-        <location filename="optionsdialog.ui" line="486"/>
         <source>This option causes a local command shell to be opened when PINN is booted. When the shell is exited, PINN will then be booted as normal.</source>
         <translation>Diese Option bewirkt, dass beim Booten von PINN eine lokale Kommandozeile geöffnet wird. Wenn die Kommandozeile beendet wird, bootet PINN wie gewohnt.</translation>
     </message>
     <message>
-        <location filename="optionsdialog.ui" line="496"/>
         <source>Prevents safemode being entered if you have external hardware that pulls pin 5 low.</source>
         <translation>Verhindert den Wechsel in den Safemode, wenn eine externe Hardware vorhanden ist, die Pin 5 auf niedrig schaltet.</translation>
     </message>
     <message>
-        <location filename="optionsdialog.ui" line="506"/>
         <source>A special boot feature to swap the priority of the DSI and HDMI video outputs, allowing an OS to give priority to a HDMI screen if attached.</source>
         <translation>Ein spezielles Boot-Feature, um die Priorität der DSI- und HDMI-Videoausgänge zu tauschen, so dass ein Betriebssystem einem HDMI-Bildschirm den Vorrang geben kann, wenn er angeschlossen ist.</translation>
     </message>
     <message>
-        <location filename="optionsdialog.ui" line="516"/>
         <source>Prevents the list of OSes from being grouped into categories.</source>
         <translation>Verhindert, dass die Liste der Betriebssysteme in Kategorien gruppiert wird.</translation>
     </message>
     <message>
-        <location filename="optionsdialog.ui" line="526"/>
         <source>Prevents the cursor from being shown on the boot selection dialog (requested for touchscreen devices)</source>
         <translation>Verhindert, dass der Mauszeiger im Boot-Auswahldialog angezeigt wird (gewünscht für Geräten mit Touchscreen)</translation>
     </message>
     <message>
-        <location filename="optionsdialog.ui" line="536"/>
         <source>Causes a customised wallpaper.jpg or wallpaper.png file to be resized to fill the entire desktop</source>
         <translation>Bewirkt, dass die Größe einer eigenen Datei wallpaper.jpg oder wallpaper.png so angepasst wird, dass sie den gesamten Desktop ausfüllt</translation>
     </message>
     <message>
-        <location filename="optionsdialog.ui" line="546"/>
-        <location filename="optionsdialog.ui" line="598"/>
         <source>Sets one of 4 simple display modes: 0=HDMI preferred, 1=HDMI safe, 2= PAL 4:3, 3=NTSC  4:3</source>
         <translation>Legt einen von 4 einfachen Anzeigemodi fest: 0=HDMI bevorzugt, 1=HDMI sicher, 2=PAL 4:3, 3=NTSC 4:3</translation>
     </message>
     <message>
-        <location filename="optionsdialog.ui" line="559"/>
-        <location filename="optionsdialog.ui" line="630"/>
         <source>Changes the style of the windows</source>
         <translation>Ändert den Fensterstil</translation>
     </message>
     <message>
-        <location filename="optionsdialog.ui" line="572"/>
-        <location filename="optionsdialog.ui" line="657"/>
         <source>Changes the default timeout allowed before an OS is booted without any selection. </source>
         <translation>Ändert die Zeitspanne, die standardmäßig verstreichen darf, bevor ein Betriebssystem ohne Auswahl gebootet wird. </translation>
     </message>
     <message>
-        <location filename="optionsdialog.ui" line="585"/>
-        <location filename="optionsdialog.ui" line="664"/>
         <source>To change the background colour for the screen and most windows, add background=r,g,b, where 0,0,0 is black and 255,255,255 is white. I suggest to use values above 127.</source>
         <translation>Um die Hintergrundfarbe für den Bildschirm und die meisten Fenster zu ändern, background=r,g,b hinzufügen, wobei 0,0,0 schwarz und 255,255,255 weiß ist. Ich empfehle, Werte über 127 zu verwenden.</translation>
     </message>
     <message>
-        <location filename="optionsdialog.ui" line="681"/>
         <source>Virtual Keyboard</source>
         <translation>Bildschirmtastatur</translation>
     </message>
     <message>
-        <location filename="optionsdialog.ui" line="69"/>
         <source>&amp;configpath=</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="optionsdialog.ui" line="96"/>
         <source>&amp;runinstaller</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="optionsdialog.ui" line="106"/>
         <source>no_&amp;update</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="optionsdialog.ui" line="116"/>
         <source>&amp;forceupdatepinn</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="optionsdialog.ui" line="126"/>
         <source>&amp;allsd</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="optionsdialog.ui" line="136"/>
         <source>all&amp;usb</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="optionsdialog.ui" line="146"/>
         <source>all&amp;network</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="optionsdialog.ui" line="156"/>
         <source>all&amp;installed</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="optionsdialog.ui" line="166"/>
         <source>&amp;waitsd</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="optionsdialog.ui" line="176"/>
         <source>waitus&amp;b</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="optionsdialog.ui" line="186"/>
         <source>waitnetwor&amp;k</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="optionsdialog.ui" line="196"/>
         <source>waita&amp;ll</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="optionsdialog.ui" line="223"/>
         <source>sil&amp;entreinstallnewer</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="optionsdialog.ui" line="233"/>
         <source>&amp;silentinstall</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="optionsdialog.ui" line="240"/>
         <source>selec&amp;t=</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="optionsdialog.ui" line="264"/>
         <source>no_&amp;default_source</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="optionsdialog.ui" line="274"/>
         <source>disable&amp;usbimages</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="optionsdialog.ui" line="284"/>
         <source>disable&amp;sdimages</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="optionsdialog.ui" line="294"/>
         <source>&amp;showall</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="optionsdialog.ui" line="304"/>
         <source>repo_&amp;list=</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="optionsdialog.ui" line="317"/>
         <source>&amp;repo=</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="optionsdialog.ui" line="337"/>
         <source>alt_&amp;image_source=</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="optionsdialog.ui" line="375"/>
         <source>&amp;remotetimeout=&lt;secs&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="optionsdialog.ui" line="388"/>
         <source>&amp;forcetrigger</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="optionsdialog.ui" line="398"/>
         <source>&amp;gpiotriggerenable</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="optionsdialog.ui" line="408"/>
         <source>&amp;networktimeout=&lt;secs&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="optionsdialog.ui" line="421"/>
         <source>&amp;keyboardtriggerdisable</source>
         <oldsource>&amp;keyboardtriggerenable</oldsource>
         <translation></translation>
     </message>
     <message>
-        <location filename="optionsdialog.ui" line="459"/>
         <source>v&amp;ncinstall</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="optionsdialog.ui" line="469"/>
         <source>&amp;vncshare</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="optionsdialog.ui" line="479"/>
         <source>&amp;ssh</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="optionsdialog.ui" line="489"/>
         <source>&amp;rescueshell</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="optionsdialog.ui" line="499"/>
         <source>disablesafe&amp;mode</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="optionsdialog.ui" line="509"/>
         <source>&amp;dsi</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="optionsdialog.ui" line="519"/>
         <source>no_&amp;group</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="optionsdialog.ui" line="529"/>
         <source>no_&amp;cursor</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="optionsdialog.ui" line="539"/>
         <source>&amp;wallpaper_resize</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="optionsdialog.ui" line="549"/>
         <source>dis&amp;play=</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="optionsdialog.ui" line="562"/>
         <source>s&amp;tyle=</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="optionsdialog.ui" line="575"/>
         <source>b&amp;ootmenutimeout=&lt;secs&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="optionsdialog.ui" line="588"/>
         <source>&amp;background=&lt;r,g,b&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="optionsdialog.ui" line="602"/>
-        <location filename="optionsdialog.ui" line="634"/>
         <source>none</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="optionsdialog.ui" line="607"/>
         <source>0</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="optionsdialog.ui" line="612"/>
         <source>1</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="optionsdialog.ui" line="617"/>
         <source>2</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="optionsdialog.ui" line="622"/>
         <source>3</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="optionsdialog.ui" line="639"/>
         <source>windows</source>
-        <translation type="unfinished"></translation>
+        <translation>Windows</translation>
     </message>
     <message>
-        <location filename="optionsdialog.ui" line="644"/>
         <source>motif</source>
-        <translation type="unfinished"></translation>
+        <translation>Motif</translation>
     </message>
     <message>
-        <location filename="optionsdialog.ui" line="649"/>
         <source>platinum</source>
-        <translation type="unfinished"></translation>
+        <translation>Platinum</translation>
     </message>
     <message>
-        <location filename="optionsdialog.cpp" line="291"/>
         <source>WARNING</source>
         <translation>WARNUNG</translation>
     </message>
     <message>
-        <location filename="optionsdialog.cpp" line="292"/>
         <source>Warning: You have chosen the &apos;runinstaller&apos; option.
 This will erase all your OSes on next boot.
 Are you sure?</source>
@@ -2140,121 +1693,113 @@ Sicher, dass das gewollt ist?</translation>
 <context>
     <name>OsGroup</name>
     <message>
-        <location filename="osgroup.cpp" line="13"/>
         <source>General</source>
         <translation>Allgemein</translation>
     </message>
     <message>
-        <location filename="osgroup.cpp" line="14"/>
         <source>Media</source>
         <translation>Medien</translation>
     </message>
     <message>
-        <location filename="osgroup.cpp" line="15"/>
         <source>Games</source>
         <translation>Spiele</translation>
     </message>
     <message>
-        <location filename="osgroup.cpp" line="16"/>
         <source>Minimal</source>
-        <translation type="unfinished"></translation>
+        <translation>Minimal</translation>
     </message>
     <message>
-        <location filename="osgroup.cpp" line="17"/>
         <source>Education</source>
         <translation>Bildung</translation>
     </message>
     <message>
-        <location filename="osgroup.cpp" line="18"/>
         <source>Installed</source>
         <translation>Installiert</translation>
     </message>
     <message>
-        <location filename="osgroup.cpp" line="19"/>
         <source>Utility</source>
-        <translation type="unfinished"></translation>
+        <translation>Utility</translation>
     </message>
     <message>
-        <location filename="osgroup.cpp" line="342"/>
+        <source>Testing</source>
+        <translation>Testen</translation>
+    </message>
+    <message>
+        <source>Legacy</source>
+        <translation>Legacy</translation>
+    </message>
+    <message>
+        <source>Sailing</source>
+        <translation>Segeln</translation>
+    </message>
+    <message>
         <source>RECOMMENDED</source>
         <translation>EMPFOHLEN</translation>
     </message>
     <message>
-        <location filename="osgroup.cpp" line="347"/>
         <source>NEW VERSION</source>
         <translation>NEUE VERSION</translation>
     </message>
     <message>
-        <location filename="osgroup.cpp" line="348"/>
         <source>UPDATE</source>
         <translation>UPDATE</translation>
     </message>
     <message>
-        <location filename="osgroup.cpp" line="352"/>
-        <location filename="osgroup.cpp" line="353"/>
         <source>INSTALLED</source>
         <translation>INSTALLIERT</translation>
+    </message>
+    <message>
+        <source>Backups</source>
+        <translation>Backups</translation>
     </message>
 </context>
 <context>
     <name>Passwd</name>
     <message>
-        <location filename="passwd.ui" line="14"/>
         <source>Reset Password</source>
         <translation>Passwort zurücksetzen</translation>
     </message>
     <message>
-        <location filename="passwd.ui" line="45"/>
         <source>Username</source>
         <translation>Benutzername</translation>
     </message>
     <message>
-        <location filename="passwd.ui" line="71"/>
         <source>Password</source>
         <translation>Passwort</translation>
     </message>
     <message>
-        <location filename="passwd.ui" line="110"/>
         <source>Retype Password</source>
         <translation>Passwort wiederholen</translation>
     </message>
     <message>
-        <location filename="passwd.ui" line="123"/>
         <source>Strength</source>
         <translation>Stärke</translation>
     </message>
     <message>
-        <location filename="passwd.ui" line="158"/>
         <source>Show Password</source>
         <translation>Passwort anzeigen</translation>
     </message>
     <message>
-        <location filename="passwd.ui" line="171"/>
         <source>Use Default</source>
         <translation>Standard verwenden</translation>
     </message>
     <message>
-        <location filename="passwd.cpp" line="226"/>
         <source>Very Weak</source>
         <translation>Sehr schwach</translation>
     </message>
     <message>
-        <location filename="passwd.cpp" line="227"/>
         <source>Weak</source>
         <translation>Schwach</translation>
     </message>
     <message>
-        <location filename="passwd.cpp" line="228"/>
         <source>Good</source>
         <translation>Gut</translation>
     </message>
     <message>
-        <location filename="passwd.cpp" line="229"/>
         <source>Strong</source>
         <translation>Stark</translation>
     </message>
     <message>
-        <location filename="passwd.cpp" line="230"/>
         <source>Very Strong</source>
         <translation>Sehr stark</translation>
     </message>
@@ -2262,22 +1807,18 @@ Sicher, dass das gewollt ist?</translation>
 <context>
     <name>ProgressSlideshowDialog</name>
     <message>
-        <location filename="progressslideshowdialog.cpp" line="251"/>
         <source>%1 MB of %2 MB read (%3 MB/sec) Remaining: %4:%5:%6</source>
         <translation>%1 MB von %2 MB gelesen (%3 MB/s)  Verbleibend: %4:%5:%6</translation>
     </message>
     <message>
-        <location filename="progressslideshowdialog.cpp" line="253"/>
         <source>%1 MB of %2 MB written (%3 MB/sec) Remaining: %4:%5:%6</source>
         <translation>%1 MB von %2 MB geschrieben (%3 MB/s)  Verbleibend: %4:%5:%6</translation>
     </message>
     <message>
-        <location filename="progressslideshowdialog.cpp" line="284"/>
         <source>%1 MB read (%2 MB/sec)</source>
         <translation>%1 MB gelesen (%2 MB/s)</translation>
     </message>
     <message>
-        <location filename="progressslideshowdialog.cpp" line="286"/>
         <source>%1 MB written (%2 MB/sec)</source>
         <translation>%1 MB geschrieben (%2 MB/s)</translation>
     </message>
@@ -2285,70 +1826,68 @@ Sicher, dass das gewollt ist?</translation>
 <context>
     <name>QDialogButtonBox</name>
     <message>
-        <location filename="languagedialog.cpp" line="26"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="languagedialog.cpp" line="28"/>
         <source>Cancel</source>
         <translation>Abbrechen</translation>
     </message>
     <message>
-        <location filename="languagedialog.cpp" line="29"/>
         <source>&amp;Cancel</source>
         <translation>&amp;Abbrechen</translation>
     </message>
     <message>
-        <location filename="languagedialog.cpp" line="30"/>
         <source>Close</source>
         <translation>Schließen</translation>
     </message>
     <message>
-        <location filename="languagedialog.cpp" line="31"/>
         <source>&amp;Close</source>
         <translation>Schl&amp;ießen</translation>
     </message>
     <message>
-        <location filename="languagedialog.cpp" line="32"/>
         <source>&amp;Yes</source>
         <translation>&amp;Ja</translation>
     </message>
     <message>
-        <location filename="languagedialog.cpp" line="33"/>
         <source>&amp;No</source>
         <translation>&amp;Nein</translation>
     </message>
     <message>
-        <location filename="languagedialog.cpp" line="34"/>
         <source>Ignore</source>
         <translation>Ignorieren</translation>
     </message>
     <message>
-        <location filename="languagedialog.cpp" line="35"/>
         <source>Show Details...</source>
         <translation>Details anzeigen …</translation>
     </message>
     <message>
-        <location filename="languagedialog.cpp" line="36"/>
         <source>Hide Details...</source>
         <translation>Details verbergen …</translation>
     </message>
     <message>
-        <location filename="languagedialog.cpp" line="27"/>
         <source>&amp;OK</source>
         <translation>&amp;OK</translation>
     </message>
 </context>
 <context>
+    <name>QMainWindow</name>
+    <message>
+        <source>For recovery mode, hold SHIFT
+click mouse
+or press joystick...</source>
+        <translation>Für den Wiederherstellungsmodus
+UMSCHALT-Taste gedrückt halten bzw.
+Maustaste oder Joystick drücken …</translation>
+    </message>
+</context>
+<context>
     <name>TermsDialog</name>
     <message>
-        <location filename="termsdialog.ui" line="14"/>
         <source>Dialog</source>
         <translation>Dialog</translation>
     </message>
     <message>
-        <location filename="termsdialog.ui" line="27"/>
         <source>Please accept these T &amp; Cs to continue.</source>
         <oldsource>Please accept these T&amp;Cs to continue.</oldsource>
         <translation>Bitte diese Geschäftsbedingungen akzeptieren um fortzusetzen.</translation>
@@ -2357,801 +1896,85 @@ Sicher, dass das gewollt ist?</translation>
 <context>
     <name>WidgetKeyboard</name>
     <message>
-        <location filename="WidgetKeyboard.ui" line="14"/>
         <source>Virtual Keyboard</source>
         <translation>Bildschirmtastatur</translation>
     </message>
     <message>
-        <location filename="WidgetKeyboard.ui" line="53"/>
-        <source>0x01000000</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="WidgetKeyboard.ui" line="59"/>
         <source>Esc</source>
-        <translation type="unfinished"></translation>
+        <translation>Esc</translation>
     </message>
     <message>
-        <location filename="WidgetKeyboard.ui" line="85"/>
-        <source>0x01000030</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="WidgetKeyboard.ui" line="88"/>
-        <source>F1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="WidgetKeyboard.ui" line="109"/>
-        <source>0x01000031</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="WidgetKeyboard.ui" line="112"/>
-        <source>F2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="WidgetKeyboard.ui" line="133"/>
-        <source>0x01000032</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="WidgetKeyboard.ui" line="136"/>
-        <source>F3</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="WidgetKeyboard.ui" line="157"/>
-        <source>0x01000033</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="WidgetKeyboard.ui" line="160"/>
-        <source>F4</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="WidgetKeyboard.ui" line="188"/>
-        <source>0x01000034</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="WidgetKeyboard.ui" line="191"/>
-        <source>F5</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="WidgetKeyboard.ui" line="212"/>
-        <source>0x01000035</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="WidgetKeyboard.ui" line="215"/>
-        <source>F6</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="WidgetKeyboard.ui" line="239"/>
-        <source>F7</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="WidgetKeyboard.ui" line="260"/>
-        <source>0x01000037</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="WidgetKeyboard.ui" line="263"/>
-        <source>F8</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="WidgetKeyboard.ui" line="291"/>
-        <source>0x01000038</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="WidgetKeyboard.ui" line="294"/>
-        <source>F9</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="WidgetKeyboard.ui" line="315"/>
-        <source>0x01000039</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="WidgetKeyboard.ui" line="318"/>
-        <source>F10</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="WidgetKeyboard.ui" line="339"/>
-        <source>0x0100003a</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="WidgetKeyboard.ui" line="342"/>
-        <source>F11</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="WidgetKeyboard.ui" line="363"/>
-        <source>0x0100003b</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="WidgetKeyboard.ui" line="366"/>
-        <source>F12</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="WidgetKeyboard.ui" line="401"/>
-        <source>0x01000006</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="WidgetKeyboard.ui" line="404"/>
         <source>Insert</source>
         <translation>Einfg</translation>
     </message>
     <message>
-        <location filename="WidgetKeyboard.ui" line="428"/>
-        <source>0x01000010</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="WidgetKeyboard.ui" line="431"/>
         <source>Home</source>
         <translation>Pos1</translation>
     </message>
     <message>
-        <location filename="WidgetKeyboard.ui" line="452"/>
-        <source>0x01000016</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="WidgetKeyboard.ui" line="455"/>
         <source>PgUP</source>
         <translation>Bild Auf</translation>
     </message>
     <message>
-        <location filename="WidgetKeyboard.ui" line="476"/>
-        <source>0x01000007</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="WidgetKeyboard.ui" line="479"/>
         <source>Delete</source>
         <translation>Entf</translation>
     </message>
     <message>
-        <location filename="WidgetKeyboard.ui" line="500"/>
-        <source>0x01000011</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="WidgetKeyboard.ui" line="503"/>
         <source>End</source>
         <translation>Ende</translation>
     </message>
     <message>
-        <location filename="WidgetKeyboard.ui" line="524"/>
-        <source>0x01000017</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="WidgetKeyboard.ui" line="527"/>
         <source>PgDn</source>
         <translation>Bild Ab</translation>
     </message>
     <message>
-        <location filename="WidgetKeyboard.ui" line="552"/>
-        <source>0x01000013</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="WidgetKeyboard.ui" line="580"/>
-        <source>0x01000012</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="WidgetKeyboard.ui" line="608"/>
-        <source>0x01000015</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="WidgetKeyboard.ui" line="636"/>
-        <source>0x01000014</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="WidgetKeyboard.ui" line="678"/>
-        <source>0x60</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="WidgetKeyboard.ui" line="681"/>
-        <source>`</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="WidgetKeyboard.ui" line="702"/>
-        <source>0x31</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="WidgetKeyboard.ui" line="705"/>
-        <source>1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="WidgetKeyboard.ui" line="726"/>
-        <source>0x32</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="WidgetKeyboard.ui" line="729"/>
-        <source>2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="WidgetKeyboard.ui" line="750"/>
-        <source>0x33</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="WidgetKeyboard.ui" line="753"/>
-        <source>3</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="WidgetKeyboard.ui" line="774"/>
-        <source>0x34</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="WidgetKeyboard.ui" line="777"/>
-        <source>4</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="WidgetKeyboard.ui" line="798"/>
-        <source>0x35</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="WidgetKeyboard.ui" line="801"/>
-        <source>5</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="WidgetKeyboard.ui" line="822"/>
-        <source>0x36</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="WidgetKeyboard.ui" line="825"/>
-        <source>6</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="WidgetKeyboard.ui" line="846"/>
-        <source>0x37</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="WidgetKeyboard.ui" line="849"/>
-        <source>7</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="WidgetKeyboard.ui" line="870"/>
-        <source>0x38</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="WidgetKeyboard.ui" line="873"/>
-        <source>8</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="WidgetKeyboard.ui" line="894"/>
-        <source>0x39</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="WidgetKeyboard.ui" line="897"/>
-        <source>9</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="WidgetKeyboard.ui" line="918"/>
-        <source>0x30</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="WidgetKeyboard.ui" line="921"/>
-        <source>0</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="WidgetKeyboard.ui" line="942"/>
-        <source>0x2d</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="WidgetKeyboard.ui" line="945"/>
-        <source>-</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="WidgetKeyboard.ui" line="966"/>
-        <source>13</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="WidgetKeyboard.ui" line="969"/>
-        <source>=</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="WidgetKeyboard.ui" line="990"/>
-        <source>0x01000003</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="WidgetKeyboard.ui" line="993"/>
         <source>Backspace</source>
         <translation>Rücktaste</translation>
     </message>
     <message>
-        <location filename="WidgetKeyboard.ui" line="1021"/>
-        <source>0x01000024</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="WidgetKeyboard.ui" line="1024"/>
         <source>    Caps   </source>
         <translation>Feststelltaste</translation>
     </message>
     <message>
-        <location filename="WidgetKeyboard.ui" line="1048"/>
-        <source>0x41</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="WidgetKeyboard.ui" line="1051"/>
-        <source>A</source>
-        <translation>A</translation>
-    </message>
-    <message>
-        <location filename="WidgetKeyboard.ui" line="1072"/>
-        <source>0x53</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="WidgetKeyboard.ui" line="1075"/>
-        <source>S</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="WidgetKeyboard.ui" line="1096"/>
-        <source>0x44</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="WidgetKeyboard.ui" line="1099"/>
-        <source>D</source>
-        <translation>D</translation>
-    </message>
-    <message>
-        <location filename="WidgetKeyboard.ui" line="1120"/>
-        <source>0x46</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="WidgetKeyboard.ui" line="1123"/>
-        <source>F</source>
-        <translation>F</translation>
-    </message>
-    <message>
-        <location filename="WidgetKeyboard.ui" line="1144"/>
-        <source>0x47</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="WidgetKeyboard.ui" line="1147"/>
-        <source>G</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="WidgetKeyboard.ui" line="1168"/>
-        <source>0x48</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="WidgetKeyboard.ui" line="1171"/>
-        <source>H</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="WidgetKeyboard.ui" line="1192"/>
-        <source>0x4a</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="WidgetKeyboard.ui" line="1195"/>
-        <source>J</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="WidgetKeyboard.ui" line="1216"/>
-        <source>0x4b</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="WidgetKeyboard.ui" line="1219"/>
-        <source>K</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="WidgetKeyboard.ui" line="1240"/>
-        <source>0x4c</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="WidgetKeyboard.ui" line="1243"/>
-        <source>L</source>
-        <translation>L</translation>
-    </message>
-    <message>
-        <location filename="WidgetKeyboard.ui" line="1264"/>
-        <source>0x3b</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="WidgetKeyboard.ui" line="1267"/>
-        <source>;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="WidgetKeyboard.ui" line="1288"/>
-        <source>0x27</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="WidgetKeyboard.ui" line="1291"/>
-        <source>&apos;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="WidgetKeyboard.ui" line="1312"/>
-        <source>0x01000004</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="WidgetKeyboard.ui" line="1315"/>
         <source>    Return   </source>
         <translation>   Eingabe   </translation>
     </message>
     <message>
-        <location filename="WidgetKeyboard.ui" line="1343"/>
-        <location filename="WidgetKeyboard.ui" line="1610"/>
-        <source>0x01000020</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="WidgetKeyboard.ui" line="1346"/>
         <source>     Shift     </source>
         <translation>   Umschalt   </translation>
     </message>
     <message>
-        <location filename="WidgetKeyboard.ui" line="1370"/>
-        <source>0x5a</source>
-        <translation>0x59</translation>
-    </message>
-    <message>
-        <location filename="WidgetKeyboard.ui" line="1373"/>
-        <source>Z</source>
-        <translation>Y</translation>
-    </message>
-    <message>
-        <location filename="WidgetKeyboard.ui" line="1394"/>
-        <source>0x58</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="WidgetKeyboard.ui" line="1397"/>
-        <source>X</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="WidgetKeyboard.ui" line="1418"/>
-        <source>0x43</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="WidgetKeyboard.ui" line="1421"/>
-        <source>C</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="WidgetKeyboard.ui" line="1442"/>
-        <source>0x56</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="WidgetKeyboard.ui" line="1445"/>
-        <source>V</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="WidgetKeyboard.ui" line="1466"/>
-        <source>0x42</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="WidgetKeyboard.ui" line="1469"/>
-        <source>B</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="WidgetKeyboard.ui" line="1490"/>
-        <source>0x4e</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="WidgetKeyboard.ui" line="1493"/>
-        <source>N</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="WidgetKeyboard.ui" line="1514"/>
-        <source>0x4d</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="WidgetKeyboard.ui" line="1517"/>
-        <source>M</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="WidgetKeyboard.ui" line="1538"/>
-        <source>0x2c</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="WidgetKeyboard.ui" line="1541"/>
-        <source>,</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="WidgetKeyboard.ui" line="1562"/>
-        <source>0x2e</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="WidgetKeyboard.ui" line="1565"/>
-        <source>.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="WidgetKeyboard.ui" line="1586"/>
-        <source>0x2f</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="WidgetKeyboard.ui" line="1589"/>
-        <source>/</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="WidgetKeyboard.ui" line="1613"/>
         <source>     Shift      </source>
         <translation>   Umschalt   </translation>
     </message>
     <message>
-        <location filename="WidgetKeyboard.ui" line="1644"/>
-        <source>0x01000021</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="WidgetKeyboard.ui" line="1647"/>
         <source>    Ctrl     </source>
         <translation>   Strg    </translation>
     </message>
     <message>
-        <location filename="WidgetKeyboard.ui" line="1671"/>
-        <source>0x01000023</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="WidgetKeyboard.ui" line="1674"/>
         <source>   Alt  </source>
         <translation>   Alt  </translation>
     </message>
     <message>
-        <location filename="WidgetKeyboard.ui" line="1698"/>
-        <source>0x20</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="WidgetKeyboard.ui" line="1717"/>
         <source>Transparency</source>
-        <translation type="unfinished">Transparenz</translation>
+        <translation">Transparenz</translation>
     </message>
     <message>
-        <location filename="WidgetKeyboard.ui" line="1745"/>
-        <source>0x01000001</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="WidgetKeyboard.ui" line="1748"/>
         <source>  Tab   </source>
-        <translation type="unfinished"></translation>
+        <translation>  Tab   </translation>
     </message>
     <message>
-        <location filename="WidgetKeyboard.ui" line="1769"/>
-        <source>0x51</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="WidgetKeyboard.ui" line="1772"/>
-        <source>Q</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="WidgetKeyboard.ui" line="1793"/>
-        <source>0x57</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="WidgetKeyboard.ui" line="1796"/>
-        <source>W</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="WidgetKeyboard.ui" line="1817"/>
-        <source>0x45</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="WidgetKeyboard.ui" line="1820"/>
-        <source>E</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="WidgetKeyboard.ui" line="1841"/>
-        <source>0x52</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="WidgetKeyboard.ui" line="1844"/>
-        <source>R</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="WidgetKeyboard.ui" line="1865"/>
-        <source>0x54</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="WidgetKeyboard.ui" line="1868"/>
-        <source>T</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="WidgetKeyboard.ui" line="1889"/>
-        <source>0x59</source>
-        <translation>0x5a</translation>
-    </message>
-    <message>
-        <location filename="WidgetKeyboard.ui" line="1892"/>
-        <source>Y</source>
-        <translation>Z</translation>
-    </message>
-    <message>
-        <location filename="WidgetKeyboard.ui" line="1913"/>
-        <source>0x55</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="WidgetKeyboard.ui" line="1916"/>
-        <source>U</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="WidgetKeyboard.ui" line="1937"/>
-        <source>0x49</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="WidgetKeyboard.ui" line="1940"/>
-        <source>I</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="WidgetKeyboard.ui" line="1961"/>
-        <source>0x4f</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="WidgetKeyboard.ui" line="1964"/>
-        <source>O</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="WidgetKeyboard.ui" line="1985"/>
-        <source>0x50</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="WidgetKeyboard.ui" line="1988"/>
-        <source>P</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="WidgetKeyboard.ui" line="2009"/>
-        <source>0x5b</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="WidgetKeyboard.ui" line="2012"/>
-        <source>[</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="WidgetKeyboard.ui" line="2033"/>
-        <source>0x5d</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="WidgetKeyboard.ui" line="2036"/>
-        <source>]</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="WidgetKeyboard.ui" line="2057"/>
-        <source>0x5c</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="WidgetKeyboard.ui" line="2060"/>
-        <source>\</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="WidgetKeyboard.ui" line="2093"/>
-        <source>0x01000009</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="WidgetKeyboard.ui" line="2096"/>
         <source>Print
 Screen</source>
         <translation>Druck
 S-Abf</translation>
     </message>
     <message>
-        <location filename="WidgetKeyboard.ui" line="2121"/>
-        <source>0x01000026</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="WidgetKeyboard.ui" line="2124"/>
         <source>Scroll
 Lock</source>
         <translation>Rollen</translation>
     </message>
     <message>
-        <location filename="WidgetKeyboard.ui" line="2149"/>
-        <source>0x01000008</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="WidgetKeyboard.ui" line="2152"/>
         <source>Pause
 Break</source>
         <translation>Pause
@@ -3161,123 +1984,155 @@ Untbr</translation>
 <context>
     <name>WifiSettingsDialog</name>
     <message>
-        <location filename="wifisettingsdialog.cpp" line="52"/>
         <source>No wifi interfaces available</source>
         <translation>Keine WLAN-Schnittstellen verfügbar</translation>
     </message>
     <message>
-        <location filename="wifisettingsdialog.cpp" line="52"/>
         <source>No wifi interfaces</source>
         <translation>Keine WLAN-Schnittstellen</translation>
     </message>
     <message>
-        <location filename="wifisettingsdialog.cpp" line="242"/>
         <source>Authenticated but still waiting for DHCP lease</source>
         <translation>Authentifiziert, aber es wird noch auf DHCP-Lease gewartet</translation>
     </message>
     <message>
-        <location filename="wifisettingsdialog.cpp" line="249"/>
         <source>Connecting to wifi failed</source>
         <translation>Verbindungsaufbau zu WLAN fehlgeschlagen</translation>
     </message>
     <message>
-        <location filename="wifisettingsdialog.cpp" line="249"/>
         <source>Connecting to the wifi access point failed. Check your password</source>
         <translation>Verbindungsaufbau zu WLAN-Accesspoint fehlgeschlagen. Bitte Passwort überprüfen</translation>
     </message>
     <message>
-        <location filename="wifisettingsdialog.cpp" line="284"/>
         <source>Cancel</source>
         <translation>Abbrechen</translation>
     </message>
     <message>
-        <location filename="wifisettingsdialog.cpp" line="290"/>
         <source>Releasing old DHCP lease</source>
         <translation>Altes DHCP-Lease wird freigegeben</translation>
     </message>
     <message>
-        <location filename="wifisettingsdialog.cpp" line="305"/>
         <source>Disconnecting</source>
         <translation>Verbindung wird beendet</translation>
     </message>
     <message>
-        <location filename="wifisettingsdialog.cpp" line="310"/>
         <source>Connecting</source>
         <translation>Verbindungsaufbau</translation>
     </message>
     <message>
-        <location filename="wifisettingsdialog.ui" line="22"/>
         <source>Wifi network selection</source>
         <translation>WLAN-Auswahl</translation>
     </message>
     <message>
-        <location filename="wifisettingsdialog.ui" line="28"/>
         <source>Wifi network</source>
         <translation>WLAN-Netzwerk</translation>
     </message>
     <message>
-        <location filename="wifisettingsdialog.ui" line="55"/>
         <source>Authentication method</source>
         <translation>Authentifizierungsart</translation>
     </message>
     <message>
-        <location filename="wifisettingsdialog.ui" line="64"/>
         <source>Pressing the &amp;WPS button on my wifi router</source>
         <oldsource>Pressing the WPS button on my wifi router</oldsource>
         <translation>&amp;WPS-Taste des WLAN-Routers drücken</translation>
     </message>
     <message>
-        <location filename="wifisettingsdialog.ui" line="71"/>
         <source>Password &amp;authentication</source>
         <oldsource>Password authentication</oldsource>
         <translation>Passwort&amp;authentifizierung</translation>
     </message>
     <message>
-        <location filename="wifisettingsdialog.ui" line="96"/>
         <source>&amp;Username</source>
         <oldsource>Username</oldsource>
         <translation>&amp;Benutzername</translation>
     </message>
     <message>
-        <location filename="wifisettingsdialog.ui" line="113"/>
         <source>&amp;Password</source>
         <translation>&amp;Passwort</translation>
     </message>
     <message>
-        <location filename="wifisettingsdialog.ui" line="130"/>
         <source>&amp;Show Password</source>
         <translation>Passwort an&amp;zeigen</translation>
     </message>
     <message>
-        <location filename="wifisettingsdialog.ui" line="146"/>
         <source>&amp;Virtual Keyboard</source>
         <translation>Bildschirm&amp;tastatur</translation>
     </message>
     <message>
-        <location filename="wifisettingsdialog.ui" line="158"/>
         <source>&amp;Delete</source>
         <translation>&amp;Löschen</translation>
     </message>
 </context>
 <context>
+    <name>adjustSizes</name>
+    <message>
+        <source>Adjust size of OSes</source>
+        <translation>Betriebssystemgröße anpassen</translation>
+    </message>
+    <message>
+        <source>Nominal (MB)</source>
+        <translation>Nominal (MB)</translation>
+    </message>
+    <message>
+        <source>Extra (MB)</source>
+        <translation>Extra (MB)</translation>
+    </message>
+    <message>
+        <source>Total (MB)</source>
+        <translation>Insgesamt (MB)</translation>
+    </message>
+    <message>
+        <source>Clear</source>
+        <translation>Leeren</translation>
+    </message>
+    <message>
+        <source>Balance</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>(*) non-expanding</source>
+        <translation>(*) non-expanding</translation>
+    </message>
+    <message>
+        <source>Capacity: 0MB</source>
+        <translation>Kapazität: 0MB</translation>
+    </message>
+    <message>
+        <source>Free: 0MB </source>
+        <translation>Frei: 0MB</translation>
+    </message>
+    <message>
+        <source>Used: 0MB</source>
+        <translation>Belegt: 0MB</translation>
+    </message>
+    <message>
+        <source>Used</source>
+        <translation>Belegt</translation>
+    </message>
+    <message>
+        <source>Free</source>
+        <translation>Frei</translation>
+    </message>
+    <message>
+        <source>Capacity</source>
+        <translation>Kapazität</translation>
+    </message>
+</context>
+<context>
     <name>backupdialog</name>
     <message>
-        <location filename="backupdialog.ui" line="14"/>
         <source>Set Backup Name</source>
         <translation>Name für Backup festlegen</translation>
     </message>
     <message>
-        <location filename="backupdialog.ui" line="61"/>
         <source>ID (date/time)</source>
         <translation>ID (Datum/Uhrzeit)</translation>
     </message>
     <message>
-        <location filename="backupdialog.ui" line="77"/>
         <source>OS name</source>
         <translation>Systemname</translation>
     </message>
     <message>
-        <location filename="backupdialog.ui" line="122"/>
         <source>Description</source>
         <translation>Beschreibung</translation>
     </message>
@@ -3285,7 +2140,6 @@ Untbr</translation>
 <context>
     <name>chkperms</name>
     <message>
-        <location filename="chkperms.ui" line="14"/>
         <source>File System Check</source>
         <translation>Dateisystemprüfung</translation>
     </message>
@@ -3293,17 +2147,14 @@ Untbr</translation>
 <context>
     <name>dlgInstall</name>
     <message>
-        <location filename="dlginstall.ui" line="14"/>
         <source>Confirm</source>
         <translation>Bestätigen</translation>
     </message>
     <message>
-        <location filename="dlginstall.ui" line="71"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;WARNING: Some OSes are already installed!&lt;/p&gt;&lt;p&gt;Continuing to install new OSes will delete your previous installation. Consider using the Replace function if you just want to replace one OS &lt;/p&gt;&lt;p&gt;To continue installing, enter &amp;quot;DELETE&amp;quot; in the box below&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;WARNUNG: Es sind bereits einige Betriebssysteme installiert!&lt;/p&gt;&lt;p&gt;Das Fortsetzen der Installation neuer Betriebssysteme löscht die vorherige Installation. Bitte überlegen, die Funktion Ersetzen zu nutzen, falls nur ein Betriebssystem ersetzt werden soll &lt;/p&gt;&lt;p&gt;Um mit dem Installieren fortzufahren, unten in das Feld &amp;quot;DELETE&amp;quot; eingeben.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="dlginstall.ui" line="93"/>
         <source>Virtual Keyboard</source>
         <translation>Bildschirmtastatur</translation>
     </message>
@@ -3311,7 +2162,6 @@ Untbr</translation>
 <context>
     <name>fscheck</name>
     <message>
-        <location filename="fscheck.ui" line="14"/>
         <source>File System Check</source>
         <translation>Dateisystemprüfung</translation>
     </message>
@@ -3319,32 +2169,26 @@ Untbr</translation>
 <context>
     <name>piCloneThread</name>
     <message>
-        <location filename="piclonethread.cpp" line="87"/>
         <source>Preparing target...</source>
         <translation>Ziel wird vorbereitet …</translation>
     </message>
     <message>
-        <location filename="piclonethread.cpp" line="116"/>
         <source>Reading Partitions...</source>
         <translation>Partitionen werden gelesen …</translation>
     </message>
     <message>
-        <location filename="piclonethread.cpp" line="161"/>
         <source>Preparing Partitions...</source>
         <translation>Partitionen werden vorbereitet …</translation>
     </message>
     <message>
-        <location filename="piclonethread.cpp" line="168"/>
         <source>Creating partition %1 of %2 </source>
         <translation>Partitionen werden erstellt: %1 von %2 </translation>
     </message>
     <message>
-        <location filename="piclonethread.cpp" line="289"/>
         <source>Copying partition %d of %d...</source>
         <translation>Partitionen werden kopiert: %d von %d …</translation>
     </message>
     <message>
-        <location filename="piclonethread.cpp" line="360"/>
         <source>Copying %1 MB of %2 MB</source>
         <translation>%1 MB von %2 MB werden kopiert</translation>
     </message>
@@ -3352,22 +2196,18 @@ Untbr</translation>
 <context>
     <name>piclonedialog</name>
     <message>
-        <location filename="piclonedialog.ui" line="14"/>
         <source>Clone SD Card</source>
         <translation>SD-Karte klonen</translation>
     </message>
     <message>
-        <location filename="piclonedialog.ui" line="42"/>
         <source>Copy From Device:</source>
         <translation>Von Gerät kopieren:</translation>
     </message>
     <message>
-        <location filename="piclonedialog.ui" line="75"/>
         <source>Copy To Device:</source>
         <translation>Auf Gerät kopieren:</translation>
     </message>
     <message>
-        <location filename="piclonedialog.ui" line="88"/>
         <source>Resize Last Partition</source>
         <translation>Größe der letzten Partition ändern</translation>
     </message>
@@ -3375,18 +2215,14 @@ Untbr</translation>
 <context>
     <name>renamedialog</name>
     <message>
-        <location filename="renamedialog.ui" line="14"/>
-        <location filename="renamedialog.ui" line="61"/>
         <source>Alias</source>
         <translation>Alias</translation>
     </message>
     <message>
-        <location filename="renamedialog.ui" line="77"/>
         <source>OS name</source>
         <translation>Systemname</translation>
     </message>
     <message>
-        <location filename="renamedialog.ui" line="122"/>
         <source>Description</source>
         <translation>Beschreibung</translation>
     </message>
@@ -3394,7 +2230,6 @@ Untbr</translation>
 <context>
     <name>repair</name>
     <message>
-        <location filename="repair.ui" line="14"/>
         <source>Repair OS</source>
         <translation>Betriebssystem reparieren</translation>
     </message>
@@ -3402,7 +2237,6 @@ Untbr</translation>
 <context>
     <name>replace</name>
     <message>
-        <location filename="replace.ui" line="14"/>
         <source>Replace Installed OSes</source>
         <translation>Installierte Betriebssysteme ersetzen</translation>
     </message>
@@ -3410,76 +2244,62 @@ Untbr</translation>
 <context>
     <name>rerunsetup</name>
     <message>
-        <location filename="rerunsetup.cpp" line="27"/>
         <source>No OSes to check</source>
         <translation>Kein Betriebssystem zu überprüfen</translation>
     </message>
     <message>
-        <location filename="rerunsetup.cpp" line="31"/>
         <source>Checking for partition_setup.sh scripts...</source>
         <translation>partition_setup.sh-Skripts werden gesucht …</translation>
     </message>
     <message>
-        <location filename="rerunsetup.cpp" line="57"/>
         <source>Cannot find setup script for </source>
         <translation>Fehler beim Finden des Setup-Skripts für</translation>
     </message>
     <message>
-        <location filename="rerunsetup.cpp" line="58"/>
         <source>Maybe insert source USB stick</source>
         <translation>Eventuell Quell-USB-Stick einstecken</translation>
     </message>
     <message>
-        <location filename="rerunsetup.cpp" line="63"/>
         <source>does not support re-running the setup script.</source>
         <translation>unterstützt nicht die erneute Ausführung des Setup-Skripts.</translation>
     </message>
     <message>
-        <location filename="rerunsetup.cpp" line="72"/>
         <source> setup script needs to be updated.</source>
         <translation> Setup-Skript benötigt eine Aktualisierung.</translation>
     </message>
     <message>
-        <location filename="rerunsetup.cpp" line="89"/>
         <source>Error in checksum for partition_setup.sh</source>
         <translation>Fehler in Prüfsumme für partition_setup.sh</translation>
     </message>
     <message>
-        <location filename="rerunsetup.cpp" line="90"/>
         <source>Expected csum= %1 Calculated= %2</source>
         <translation>Erwartete Prüfsumme= %1 Berechnet= %2</translation>
     </message>
     <message>
-        <location filename="rerunsetup.cpp" line="155"/>
         <source>%1: Error executing partition setup script</source>
         <translation>%1: Fehler beim Ausführen des Skripts für die Partitionserstellung</translation>
     </message>
     <message>
-        <location filename="rerunsetup.cpp" line="160"/>
         <source> partions_setup.sh script error
 </source>
         <translation> partition_setup.sh Skriptfehler
 </translation>
     </message>
     <message>
-        <location filename="rerunsetup.cpp" line="162"/>
         <source> partition_setup.sh script OK
 </source>
         <translation> partition_setup.sh Skript OK
 </translation>
     </message>
     <message>
-        <location filename="rerunsetup.cpp" line="169"/>
         <source>DONE - some setup script errors detected</source>
         <translation>FERTIG - Einige Setup-Skript-Fehler erkannt</translation>
     </message>
     <message>
-        <location filename="rerunsetup.cpp" line="171"/>
         <source>DONE - SUCCESSFUL setup scripts exeuted</source>
         <translation>FERTIG - ERFOLGREICH Setup-Skripts ausgeführt</translation>
     </message>
     <message>
-        <location filename="rerunsetup.ui" line="14"/>
         <source>re-run partition_setup</source>
         <translation>partition_setup erneut ausführen</translation>
     </message>
@@ -3487,12 +2307,10 @@ Untbr</translation>
 <context>
     <name>showlog</name>
     <message>
-        <location filename="showlog.ui" line="14"/>
         <source>Show Log</source>
         <translation>Protokoll anzeigen</translation>
     </message>
     <message>
-        <location filename="showlog.ui" line="55"/>
         <source>&amp;Refresh</source>
         <translation>&amp;Aktualisieren</translation>
     </message>


### PR DESCRIPTION
Updated German translation file:
- added a lot of missing translations
- corrected spelling errors (such as "Betrie**bsy**stem" etc.)
- changed translations according to translation guidelines for German language ([Gnome](https://wiki.gnome.org/de/UebersetzungsRichtlinien)/Debian) etc.

