### PR TITLE
Added docker build support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+buildroot/output
+buildroot/dl

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM ubuntu:20.04
+FROM stpos-multiboot
+#ubuntu:20.04
 LABEL authors="Tobias Madlberger"
 
 RUN apt-get update
@@ -12,6 +13,7 @@ RUN apt-get update && apt-get install -y \
     whois  \
     unzip  \
     bc  \
+    gcc=4:9.3.0-1ubuntu2 \
     qt4-linguist-tools \
     libssl-dev \
     git \
@@ -19,7 +21,8 @@ RUN apt-get update && apt-get install -y \
     cpio \
     python2
 
-RUN ln -s /usr/bin/python2 /usr/bin/python
+RUN if [[ ! -f /usr/bin/python ]] ; then n -s /usr/bin/python2 /usr/bin/python ; else echo Python already linked ; fi
+
 RUN wget https://www.libarchive.org/downloads/libarchive-3.3.1.tar.gz
 RUN tar xzf libarchive-3.3.1.tar.gz
 WORKDIR libarchive-3.3.1
@@ -27,6 +30,6 @@ RUN ./configure
 RUN make
 RUN make install
 
-WORKDIR /home/dev/PINN
+WORKDIR /home/dev/StpOs-Multiboot
 
-CMD ["./BUILDME.sh"]
+CMD ["./build.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,32 @@
+FROM ubuntu:20.04
+LABEL authors="Tobias Madlberger"
+
+RUN apt-get update
+RUN apt install -y software-properties-common
+RUN add-apt-repository -y ppa:rock-core/qt4
+RUN apt-get update && apt-get install -y \
+    build-essential  \
+    rsync  \
+    texinfo  \
+    libncurses-dev  \
+    whois  \
+    unzip  \
+    bc  \
+    qt4-linguist-tools \
+    libssl-dev \
+    git \
+    wget \
+    cpio \
+    python2
+
+RUN ln -s /usr/bin/python2 /usr/bin/python
+RUN wget https://www.libarchive.org/downloads/libarchive-3.3.1.tar.gz
+RUN tar xzf libarchive-3.3.1.tar.gz
+WORKDIR libarchive-3.3.1
+RUN ./configure
+RUN make
+RUN make install
+
+WORKDIR /home/dev/PINN
+
+CMD ["./BUILDME.sh"]

--- a/README_PINN.md
+++ b/README_PINN.md
@@ -1233,6 +1233,20 @@ to lower the number to prevent swapping:
 
 If your build machine also has some QT5 components, it is useful to `export QT_SELECT=4` before building to ensure the QT4 component versions are selected.
 
+## Build using docker
+
+When using docker, all required packages will get installed automatically when running, making sure the container is able to build PINN.
+When you run the container first time, it'll download all packages and (maybe) ubuntu20.04. Once that's done, it's recommended to create an image from this container,
+so you don't have to download it over and over again. Use `docker commit <container-id> pinn-build-image`. Then you have to change all references to ubuntu:20.04
+  with pinn-build-image in the Dockerfile and docker-compose.yml
+
+Starting the build on linux:
+`sudo docker-compose up`
+
+This will execute all the builds and output the binary file into the buildroot/output folder, just like when you execute the BUIDME.sh directly.
+
+The output folder will be created during runtime.
+
 ## How to run your Build
 
 In order to set up an SD card with a newly built version of PINN, you will need to:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+version: "3"
+
+services:
+  build-stp-os-multiboot:
+    image: ubuntu:20.04
+    build: .
+    volumes:
+      - path/to/local/pinn/repo:/home/dev/PINN


### PR DESCRIPTION
As mentioned in #721 after the build process worked for me, I'll create a pull request, so others don't have to go through the tedious process of fixing buildroot issues with the docker ubuntu image.

Docker allows to run a linux image that, in this case, only builds the project, with the required libraries installed by default.

In this pull request I added following files:
Dockerfile - These are the instructions to create the image with all required packages
docker-compose.yml

I modified this file:
README_PINN.md - I added a section at the bottom for build instructions for PINN with an docker files using the files added in this pull request.



For anything, that might prevent this pull request from getting merged, I'd be happy to be notified about, so I can fix them