### PR TITLE
Update Italian language

### DIFF
--- a/recovery/translation_it.ts
+++ b/recovery/translation_it.ts
@@ -1178,12 +1178,12 @@ Sei sicuro di voler continuare?</translation>
     <message>
         <location filename="mainwindow.cpp" line="4515"/>
         <source>PINN will now update and reboot in a few secs...</source>
-        <translation type="unfinished"></translation>
+        <translation>PINN ora si aggiornerà e si riavvierà tra pochi secondi...</translation>
     </message>
     <message>
         <location filename="mainwindow.cpp" line="4536"/>
         <source>PINN update failed</source>
-        <translation type="unfinished"></translation>
+        <translation>Aggiornamento PINN non riuscito</translation>
     </message>
     <message>
         <location filename="mainwindow.cpp" line="4596"/>
@@ -1193,32 +1193,34 @@ Sei sicuro di voler continuare?</translation>
     <message>
         <location filename="mainwindow.cpp" line="4628"/>
         <source>Saving current version</source>
-        <translation type="unfinished"></translation>
+        <translation>Salvataggio versione attuale</translation>
     </message>
     <message>
         <location filename="mainwindow.cpp" line="4637"/>
         <source>Executing preupdate</source>
-        <translation type="unfinished"></translation>
+        <translation>Esecuzione pre-aggiornamento</translation>
     </message>
     <message>
         <location filename="mainwindow.cpp" line="4646"/>
         <source>Extracting update</source>
-        <translation type="unfinished"></translation>
+        <translation>Estrazione aggiornamento</translation>
     </message>
     <message>
         <location filename="mainwindow.cpp" line="4655"/>
         <source>Executing updatepinn</source>
-        <translation type="unfinished"></translation>
+        <translation>Esecuzione aggiornamento PINN</translation>
     </message>
     <message>
         <location filename="mainwindow.cpp" line="4669"/>
         <source>Update failed. Restoring previous version.</source>
-        <translation type="unfinished"></translation>
+        <translation>Aggiornamento non riuscito. 
+Ripristino versione precedente.</translation>
     </message>
     <message>
         <location filename="mainwindow.cpp" line="4676"/>
         <source>Update failed. Restoring previous version</source>
-        <translation type="unfinished"></translation>
+        <translation>Aggiornamento non riuscito. 
+Ripristino della versione precedente</translation>
     </message>
     <message>
         <location filename="mainwindow.cpp" line="4690"/>


### PR DESCRIPTION
@procount 

Please merge,. Thanks.

Please check these probably issues regarding translation

"Executing updatepinn" 
probably should be 
"Executing PINN update"

"Update failed. Restoring previous version" has a minng "." at the end.
Should be "Update failed. Restoring previous version"

Please thake care thath there are both version
"Update failed. Restoring previous version"
"Update failed. Restoring previous version."

Please consiuder (I already asked in the apst) to remove source lines reference in .ts file.
It helps to check if theer are real diffrence in .ts files between different builds.

