### PR TITLE
Update translation_de.ts (fix)

### DIFF
--- a/recovery/translation_de.ts
+++ b/recovery/translation_de.ts
@@ -943,15 +943,15 @@ Soll fortgesetzt werden?</translation>
     </message>
     <message>
         <source>install</source>
-        <translation>installieren</translation>
+        <translation>Installation</translation>
     </message>
     <message>
         <source>reinstall</source>
-        <translation>neu installieren</translation>
+        <translation>Neuistallation</translation>
     </message>
     <message>
         <source>replace</source>
-        <translation>ersetzen</translation>
+        <translation>Ersetzen</translation>
     </message>
     <message>
         <source>USB drive</source>


### PR DESCRIPTION
These words appear to be used as nouns and must therefore be capitalized in German.